### PR TITLE
Path improvification

### DIFF
--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -106,7 +106,8 @@ PathForEachSocket::iterator PathForEachSocket::begin() const {
 }
     
 PathForEachSocket::iterator PathForEachSocket::end() const {
-    return iterator(graph->path_end(path), false, graph);
+    // we will end on the beginning step in circular paths
+    return iterator(graph->get_is_circular(path) ? graph->path_begin(path) : graph->path_end(path), false, graph);
 }
     
 PathForEachSocket::iterator::iterator(const step_handle_t& step, bool force_unequal,

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -72,15 +72,15 @@ bool HandleGraph::has_edge(const handle_t& left, const handle_t& right) const {
     return !not_seen;
 }
 
-std::vector<occurrence_handle_t> PathHandleGraph::occurrences_of_handle(const handle_t& handle,
-                                                                        bool match_orientation) const {
-    std::vector<occurrence_handle_t> found;
+std::vector<step_handle_t> PathHandleGraph::steps_of_handle(const handle_t& handle,
+                                                            bool match_orientation) const {
+    std::vector<step_handle_t> found;
     
-    for_each_occurrence_on_handle(handle, [&](const occurrence_handle_t& occ) {
-        // For each handle occurrence
-        if (!match_orientation || get_is_reverse(handle) == get_is_reverse(get_occurrence(occ))) {
+    for_each_step_on_handle(handle, [&](const step_handle_t& step) {
+        // For each handle step
+        if (!match_orientation || get_is_reverse(handle) == get_is_reverse(get_handle_of_step(step))) {
             // If its orientation is acceptable, keep it
-            found.push_back(occ);
+            found.push_back(step);
         }
     });
     
@@ -90,7 +90,7 @@ std::vector<occurrence_handle_t> PathHandleGraph::occurrences_of_handle(const ha
 bool PathHandleGraph::is_empty(const path_handle_t& path_handle) const {
     // By default, we can answer emptiness queries with the length query.
     // But some implementations may have an expensive length query and a cheaper emptiness one
-    return get_occurrence_count(path_handle) == 0;
+    return get_step_count(path_handle) == 0;
 }
 
 /// Define equality on handles
@@ -113,13 +113,13 @@ bool operator!=(const path_handle_t& a, const path_handle_t& b) {
     return as_integer(a) != as_integer(b);
 }
 
-/// Define equality on occurrence handles
-bool operator==(const occurrence_handle_t& a, const occurrence_handle_t& b) {
+/// Define equality on step handles
+bool operator==(const step_handle_t& a, const step_handle_t& b) {
     return as_integers(a)[0] == as_integers(b)[0] && as_integers(a)[1] == as_integers(b)[1];
 }
 
-/// Define inequality on occurrence handles
-bool operator!=(const occurrence_handle_t& a, const occurrence_handle_t& b) {
+/// Define inequality on step handles
+bool operator!=(const step_handle_t& a, const step_handle_t& b) {
     return !(a == b);
 }
 

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -92,6 +92,45 @@ bool PathHandleGraph::is_empty(const path_handle_t& path_handle) const {
     // But some implementations may have an expensive length query and a cheaper emptiness one
     return get_step_count(path_handle) == 0;
 }
+    
+PathForEachSocket PathHandleGraph::scan_path(const path_handle_t& path) const {
+    return PathForEachSocket(this, path);
+}
+    
+PathForEachSocket::PathForEachSocket(const PathHandleGraph* graph, const path_handle_t& path) : graph(graph), path(path) {
+    
+}
+    
+PathForEachSocket::iterator PathForEachSocket::begin() const {
+    return iterator(graph->path_begin(path), graph->get_is_circular(path) && !graph->is_empty(path), graph);
+}
+    
+PathForEachSocket::iterator PathForEachSocket::end() const {
+    return iterator(graph->path_end(path), false, graph);
+}
+    
+PathForEachSocket::iterator::iterator(const step_handle_t& step, bool force_unequal,
+                                      const PathHandleGraph* graph) : step(step), force_unequal(force_unequal), graph(graph) {
+    
+}
+    
+PathForEachSocket::iterator& PathForEachSocket::iterator::operator++() {
+    step = graph->get_next_step(step);
+    force_unequal = false;
+    return *this;
+}
+
+step_handle_t PathForEachSocket::iterator::operator*() const {
+    return step;
+}
+
+bool PathForEachSocket::iterator::operator==(const PathForEachSocket::iterator& other) const {
+    return !force_unequal && !other.force_unequal && graph == other.graph && step == other.step;
+}
+
+bool PathForEachSocket::iterator::operator!=(const PathForEachSocket::iterator& other) const {
+    return !(*this == other);
+}
 
 /// Define equality on handles
 bool operator==(const handle_t& a, const handle_t& b) {

--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -120,8 +120,8 @@ PathForEachSocket::iterator& PathForEachSocket::iterator::operator++() {
     return *this;
 }
 
-step_handle_t PathForEachSocket::iterator::operator*() const {
-    return step;
+handle_t PathForEachSocket::iterator::operator*() const {
+    return graph->get_handle_of_step(step);
 }
 
 bool PathForEachSocket::iterator::operator==(const PathForEachSocket::iterator& other) const {

--- a/src/include/handlegraph/deletable_handle_graph.hpp
+++ b/src/include/handlegraph/deletable_handle_graph.hpp
@@ -34,7 +34,7 @@ public:
         destroy_edge(edge.first, edge.second);
     }
     
-    /// Remove all nodes and edges. Does not update any stored paths.
+    /// Remove all nodes and edges.
     virtual void clear() = 0;
 };
 

--- a/src/include/handlegraph/mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_handle_graph.hpp
@@ -18,9 +18,6 @@ namespace handlegraph {
  */
 class MutableHandleGraph : virtual public HandleGraph {
 public:
-    /*
-     * Note: All operations may invalidate path handles and occurrence handles.
-     */
     
     /// Create a new node with the given sequence and return the handle.
     virtual handle_t create_handle(const std::string& sequence) = 0;

--- a/src/include/handlegraph/mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_handle_graph.hpp
@@ -36,19 +36,6 @@ public:
     inline void create_edge(const edge_t& edge) {
         create_edge(edge.first, edge.second);
     }
-    
-    /// Swap the nodes corresponding to the given handles, in the ordering used
-    /// by for_each_handle when looping over the graph. Other handles to the
-    /// nodes being swapped must not be invalidated. If a swap is made while
-    /// for_each_handle is running, it affects the order of the handles
-    /// traversed during the current traversal (so swapping an already seen
-    /// handle to a later handle's position will make the seen handle be visited
-    /// again and the later handle not be visited at all).
-    virtual void swap_handles(const handle_t& a, const handle_t& b) = 0;
-
-    /// Reorder the graph's internal structure to match that given.
-    /// Optionally compact the id space of the graph to match the ordering, from 1->|ordering|.
-    virtual void apply_ordering(const std::vector<handle_t>& order, bool compact_ids) = 0;
 
     /// Alter the node that the given handle corresponds to so the orientation
     /// indicated by the handle becomes the node's local forward orientation.

--- a/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
@@ -14,9 +14,10 @@ namespace handlegraph {
 /**
  * This is the interface for a graph which is deletable and which has paths which are also mutable.
  */
-class MutablePathDeletableHandleGraph : virtual public MutablePathHandleGraph, virtual public DeletableHandleGraph {
+class MutablePathDeletableHandleGraph : virtual public MutablePathMutableHandleGraph, virtual public DeletableHandleGraph {
     
     // No extra methods. Deleting a node or edge that is contained in a path is undefined behavior.
+    // The method clear() is now assumed to delete paths as well as nodes and edges.
 };
 
 }

--- a/src/include/handlegraph/mutable_path_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_handle_graph.hpp
@@ -20,7 +20,7 @@ class MutablePathHandleGraph : virtual public PathHandleGraph {
 public:
     
     /**
-     * Destroy the given path. Invalidates handles to the path and its node occurrences.
+     * Destroy the given path. Invalidates handles to the path and its steps.
      */
     virtual void destroy_path(const path_handle_t& path) = 0;
 
@@ -30,14 +30,25 @@ public:
      * Returns a handle to the created empty path. Handles to other paths must
      * remain valid.
      */
-    virtual path_handle_t create_path_handle(const std::string& name) = 0;
+    virtual path_handle_t create_path_handle(const std::string& name,
+                                             bool is_circular = false) = 0;
     
     /**
      * Append a visit to a node to the given path. Returns a handle to the new
-     * final occurrence on the path which is appended. Handles to prior
-     * occurrences on the path, and to other paths, must remain valid.
+     * final step on the path which is appended. If the path is cirular, the new
+     * step is placed between the steps considered "last" and "first" by the
+     * method path_begin. Handles to prior steps on the path, and to other paths,
+     * must remain valid.
      */
-    virtual occurrence_handle_t append_occurrence(const path_handle_t& path, const handle_t& to_append) = 0;
+    virtual step_handle_t append_step(const path_handle_t& path, const handle_t& to_append) = 0;
+    
+    /**
+     * Make a path circular or non-circular. If the path is becoming circular, the
+     * last step is joined to the first step. If the path is becoming linear, the
+     * step considered "last" is unjoined from the step considered "first" according
+     * to the method path_begin.
+     */
+    virtual void set_circularity(const path_handle_t& path, bool circular) = 0;
 };
 
 

--- a/src/include/handlegraph/mutable_path_mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_mutable_handle_graph.hpp
@@ -16,8 +16,8 @@ namespace handlegraph {
 class MutablePathMutableHandleGraph : virtual public MutablePathHandleGraph, virtual public MutableHandleGraph {
     
     // No extra methods. However, some additional semantics are assumed:
-    // - divide_handle() replaces the occurrence of the original handle with its subsegments
-    //   in all occurrences on all paths
+    // - divide_handle() replaces every occurrence of the original handle with its subsegments
+    //   in all stesps on all paths
     // - apply_orientation() also applies the orientation to all occurrences of the handle
     //   in all paths
     

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -21,6 +21,9 @@ public:
     // Path handle interface that needs to be implemented
     ////////////////////////////////////////////////////////////////////////////
     
+    /// Returns the number of paths stored in the graph
+    virtual size_t get_path_count() const = 0;
+    
     /// Determine if a path name exists and is legal to get a path handle for.
     virtual bool has_path(const std::string& path_name) const = 0;
     
@@ -31,37 +34,43 @@ public:
     /// Look up the name of a path from a handle to it
     virtual std::string get_path_name(const path_handle_t& path_handle) const = 0;
     
-    /// Returns the number of node occurrences in the path
-    virtual size_t get_occurrence_count(const path_handle_t& path_handle) const = 0;
-
-    /// Returns the number of paths stored in the graph
-    virtual size_t get_path_count() const = 0;
+    /// Look up whether a path is circular
+    virtual bool get_is_circular(const path_handle_t& path_handle) const = 0;
     
-    /// Get a node handle (node ID and orientation) from a handle to an occurrence on a path
-    virtual handle_t get_occurrence(const occurrence_handle_t& occurrence_handle) const = 0;
+    /// Returns the number of node steps in the path
+    virtual size_t get_step_count(const path_handle_t& path_handle) const = 0;
     
-    /// Get a handle to the first occurrence in a path.
-    /// The path MUST be nonempty.
-    virtual occurrence_handle_t get_first_occurrence(const path_handle_t& path_handle) const = 0;
+    /// Get a node handle (node ID and orientation) from a handle to an step on a path
+    virtual handle_t get_handle_of_step(const step_handle_t& step_handle) const = 0;
     
-    /// Get a handle to the last occurrence in a path
-    /// The path MUST be nonempty.
-    virtual occurrence_handle_t get_last_occurrence(const path_handle_t& path_handle) const = 0;
+    /// Returns a handle to the path that an step is on
+    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const = 0;
     
-    /// Returns true if the occurrence is not the last occurence on the path, else false
-    virtual bool has_next_occurrence(const occurrence_handle_t& occurrence_handle) const = 0;
+    /// Get a handle to the first step, or in a circular path to an arbitrary step
+    /// considered "first". If the path is empty, returns the past-the-last step
+    /// returned by path_end.
+    virtual step_handle_t path_begin(const path_handle_t& path_handle) const = 0;
     
-    /// Returns true if the occurrence is not the first occurence on the path, else false
-    virtual bool has_previous_occurrence(const occurrence_handle_t& occurrence_handle) const = 0;
+    /// Get a handle to a fictitious position past the end of a path. This position is
+    /// return by get_next_step for the final step in a path in a non-circular path.
+    /// Note that get_next_step will *NEVER* return this value for a circular path.
+    virtual step_handle_t path_end(const path_handle_t& path_handle) const = 0;
     
-    /// Returns a handle to the next occurrence on the path
-    virtual occurrence_handle_t get_next_occurrence(const occurrence_handle_t& occurrence_handle) const = 0;
+    /// Returns a handle to the next step on the path. If the given step is the final step
+    /// of a non-circular path, returns the past-the-last step that is also returned by
+    /// path_end. In a circular path, the "last" step will loop around to the "first" (i.e.
+    /// the one returned by path_begin).
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    virtual step_handle_t get_next_step(const step_handle_t& step_handle) const = 0;
     
-    /// Returns a handle to the previous occurrence on the path
-    virtual occurrence_handle_t get_previous_occurrence(const occurrence_handle_t& occurrence_handle) const = 0;
-    
-    /// Returns a handle to the path that an occurrence is on
-    virtual path_handle_t get_path_handle_of_occurrence(const occurrence_handle_t& occurrence_handle) const = 0;
+    /// Returns a handle to the previous step on the path. If the given step is the first
+    /// step of a non-circular path, this method has undefined behavior. In a circular path,
+    /// it will loop around from the "first" step (i.e. the one returned by path_begin) to
+    /// the "last" step.
+    /// Note: to iterate over each step one time, even in a circular path, consider
+    /// for_each_step_in_path.
+    virtual step_handle_t get_previous_step(const step_handle_t& step_handle) const = 0;
     
     ////////////////////////////////////////////////////////////////////////////
     // Stock interface that uses backing virtual methods
@@ -73,11 +82,11 @@ public:
     template<typename Iteratee>
     bool for_each_path_handle(const Iteratee& iteratee) const;
     
-    /// Execute a function on each occurrence (occurrence_handle_t) of a handle
+    /// Execute a function on each step (step_handle_t) of a handle
     /// in any path. If it returns bool and returns false, stop iteration.
     /// Returns true if we finished and false if we stopped early.
     template<typename Iteratee>
-    bool for_each_occurrence_on_handle(const handle_t& handle, const Iteratee& iteratee) const;
+    bool for_each_step_on_handle(const handle_t& handle, const Iteratee& iteratee) const;
     
     ////////////////////////////////////////////////////////////////////////////
     // Backing protected virtual methods that need to be implemented
@@ -89,11 +98,11 @@ protected:
     /// iteration. Returns true if we finished and false if we stopped early.
     virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const = 0;
     
-    /// Execute a function on each occurrence of a handle in any path. If it
+    /// Execute a function on each step of a handle in any path. If it
     /// returns false, stop iteration. Returns true if we finished and false if
     /// we stopped early.
-    virtual bool for_each_occurrence_on_handle_impl(const handle_t& handle,
-        const std::function<bool(const occurrence_handle_t&)>& iteratee) const = 0;
+    virtual bool for_each_step_on_handle_impl(const handle_t& handle,
+        const std::function<bool(const step_handle_t&)>& iteratee) const = 0;
 
 public:
 
@@ -101,10 +110,10 @@ public:
     // Additional optional interface with a default implementation
     ////////////////////////////////////////////////////////////////////////////
     
-    /// Returns a vector of all occurrences of a node on paths. Optionally restricts to
-    /// occurrences that match the handle in orientation.
-    virtual std::vector<occurrence_handle_t> occurrences_of_handle(const handle_t& handle,
-                                                                   bool match_orientation = false) const;
+    /// Returns a vector of all steps of a node on paths. Optionally restricts to
+    /// steps that match the handle in orientation.
+    virtual std::vector<step_handle_t> steps_of_handle(const handle_t& handle,
+                                                       bool match_orientation = false) const;
 
     /// Returns true if the given path is empty, and false otherwise
     virtual bool is_empty(const path_handle_t& path_handle) const;
@@ -113,11 +122,13 @@ public:
     // Concrete utility methods
     ////////////////////////////////////////////////////////////////////////////
 
-    /// Loop over all the occurrences (occurrence_handle_t) along a path, from
-    /// first through last. If the iteratee returns bool, and it returns false,
-    /// stop. Returns true if we finished and false if we stopped early.
+    /// Loop over all the steps (step_handle_t) along a path. In a non-circular
+    /// path, iterates from first through last step. In a circular path, iterates
+    /// from the step returned by path_begin forward around to the step immediately
+    /// before it. If the iteratee returns bool, and it returns false, stop. Returns
+    /// true if we finished and false if we stopped early.
     template<typename Iteratee>
-    bool for_each_occurrence_in_path(const path_handle_t& path, const Iteratee& iteratee) const;
+    bool for_each_step_in_path(const path_handle_t& path, const Iteratee& iteratee) const;
 };
 
 ////////////////////////////////////////////////////////////////////////////
@@ -130,30 +141,29 @@ bool PathHandleGraph::for_each_path_handle(const Iteratee& iteratee) const {
 }
 
 template<typename Iteratee>
-bool PathHandleGraph::for_each_occurrence_on_handle(const handle_t& handle, const Iteratee& iteratee) const {
-    return for_each_occurrence_on_handle_impl(handle, BoolReturningWrapper<Iteratee, occurrence_handle_t>::wrap(iteratee));
+bool PathHandleGraph::for_each_step_on_handle(const handle_t& handle, const Iteratee& iteratee) const {
+    return for_each_step_on_handle_impl(handle, BoolReturningWrapper<Iteratee, step_handle_t>::wrap(iteratee));
 }
 
 
 template<typename Iteratee>
-bool PathHandleGraph::for_each_occurrence_in_path(const path_handle_t& path, const Iteratee& iteratee) const {
-    if (is_empty(path)) {
-        // Nothing to do!
-        return true;
-    }
+bool PathHandleGraph::for_each_step_in_path(const path_handle_t& path, const Iteratee& iteratee) const {
+
+    auto wrapped = BoolReturningWrapper<Iteratee, step_handle_t>::wrap(iteratee);
+    // Otherwise the path is nonempty so it is safe to try and grab a first step
     
-    auto wrapped = BoolReturningWrapper<Iteratee, occurrence_handle_t>::wrap(iteratee);
+    // Get the value that the step should be when we are done
+    auto end = get_is_circular(path) ? path_begin(path) : path_end(path);
     
+    // We might need to ignore the fact that we meet the ending condition in the first
+    // iteration on non-empty circular paths
+    bool ignore_end = !is_empty(path) && get_is_circular(path);
+    // Allow the iteratee to set a bail-out condition
     bool keep_going = true;
-    
-    // Otherwise the path is nonempty so it is safe to try and grab a first occurrence
-    auto here = get_first_occurrence(path);
-    // Run for the first occurrence
-    keep_going &= wrapped(here);
-    while (has_next_occurrence(here) && keep_going) {
-        // Run for all subsequent occurrences on the path
-        here = get_next_occurrence(here);
+    for (auto here = path_begin(path); keep_going && (ignore_end || here != end); here = get_next_step(here)) {
+        // Execute the iteratee on this step
         keep_going &= wrapped(here);
+        ignore_end = false;
     }
     
     return keep_going;

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -127,7 +127,7 @@ public:
 
     /// Returns a class with an STL-style iterator interface that can be used directly
     /// in a for each loop like:
-    /// for (step_handle_t step : graph->scan_path(path)) { }
+    /// for (handle_t handle : graph->scan_path(path)) { }
     PathForEachSocket scan_path(const path_handle_t& path) const;
     
     /// Loop over all the steps (step_handle_t) along a path. In a non-circular
@@ -202,7 +202,7 @@ public:
         iterator(const iterator& other) = default;
         iterator& operator=(const iterator& other) = default;
         iterator& operator++();
-        step_handle_t operator*() const;
+        handle_t operator*() const;
         bool operator==(const iterator& other) const;
         bool operator!=(const iterator& other) const;
         

--- a/src/include/handlegraph/types.hpp
+++ b/src/include/handlegraph/types.hpp
@@ -11,23 +11,29 @@
 
 namespace handlegraph {
 
-/// represents an id
+/// Represents an id
 typedef int64_t nid_t;
+    
 [[deprecated("id_t collides with a standard type, use nid_t instead")]]
 typedef nid_t id_t;
-/// represents an offset
+    
+/// Represents an offset
 typedef std::size_t off_t;
-/// represents a position
+    
+/// Represents a position
 typedef std::tuple<nid_t, bool, off_t> pos_t;
-/// represents the internal id of a node traversal
+    
+/// Represents the internal id of a node traversal
 struct handle_t { char data[sizeof(nid_t)]; };
-/// represents an edge in terms of its endpoints
+    
+/// Represents an edge in terms of its endpoints
 typedef std::pair<handle_t, handle_t> edge_t;
-/// represents the internal id of a path entity
+    
+/// Represents the internal id of a path entity
 struct path_handle_t { char data[sizeof(int64_t)]; };
-/// An occurrence handle is an opaque reference to an occurrence of an oriented node along a path in a graph
-/// In dg, it refers to [0], a node id/rank/handle, and [1], a rank within the records on that node
-struct occurrence_handle_t { char data[2 * sizeof(int64_t)]; };
+    
+/// A step handle is an opaque reference to a single step of an oriented node on a path in a graph
+struct step_handle_t { char data[2 * sizeof(int64_t)]; };
 
 /// Define equality on handles
 bool operator==(const handle_t& a, const handle_t& b);
@@ -41,11 +47,11 @@ bool operator==(const path_handle_t& a, const path_handle_t& b);
 /// Define inequality on path handles
 bool operator!=(const path_handle_t& a, const path_handle_t& b);
 
-/// Define equality on occurrence handles
-bool operator==(const occurrence_handle_t& a, const occurrence_handle_t& b);
+/// Define equality on step handles
+bool operator==(const step_handle_t& a, const step_handle_t& b);
 
-/// Define inequality on occurrence handles
-bool operator!=(const occurrence_handle_t& a, const occurrence_handle_t& b);
+/// Define inequality on step handles
+bool operator!=(const step_handle_t& a, const step_handle_t& b);
 
 }
 

--- a/src/include/handlegraph/util.hpp
+++ b/src/include/handlegraph/util.hpp
@@ -88,17 +88,17 @@ inline const path_handle_t& as_path_handle(const uint64_t& value) {
 }
 
 //
-// Occurrence handles
+// Step handles
 //
 
-/// View an occurrence handle as an integer
-inline int64_t* as_integers(occurrence_handle_t& occurrence_handle) {
-    return reinterpret_cast<int64_t*>(&occurrence_handle);
+/// View an occurrence handle as an integer array
+inline int64_t* as_integers(step_handle_t& step_handle) {
+    return reinterpret_cast<int64_t*>(&step_handle);
 }
 
-/// View a const occurrence handle as a const integer
-inline const int64_t* as_integers(const occurrence_handle_t& occurrence_handle) {
-    return reinterpret_cast<const int64_t*>(&occurrence_handle);
+/// View a const occurrence handle as a const integer array
+inline const int64_t* as_integers(const step_handle_t& step_handle) {
+    return reinterpret_cast<const int64_t*>(&step_handle);
 }
 
 

--- a/src/include/handlegraph/util.hpp
+++ b/src/include/handlegraph/util.hpp
@@ -91,12 +91,12 @@ inline const path_handle_t& as_path_handle(const uint64_t& value) {
 // Step handles
 //
 
-/// View an occurrence handle as an integer array
+/// View a step handle as an integer array
 inline int64_t* as_integers(step_handle_t& step_handle) {
     return reinterpret_cast<int64_t*>(&step_handle);
 }
 
-/// View a const occurrence handle as a const integer array
+/// View a const step handle as a const integer array
 inline const int64_t* as_integers(const step_handle_t& step_handle) {
     return reinterpret_cast<const int64_t*>(&step_handle);
 }


### PR DESCRIPTION
This PR resolves all of our oustanding issues! (https://github.com/vgteam/libhandlegraph/issues/2, https://github.com/vgteam/libhandlegraph/issues/3, https://github.com/vgteam/libhandlegraph/issues/4)

Specifically, the changes included are:
- Removed `swap_handles` and `apply_ordering`.
- Make `MutablePathDeletableHandleGraph` actually inherit from `MutablePathMutableHandleGraph`.
- Changed documentation to indicate that `MutablePathDeletableHandleGraph`s are expected to delete paths when calling `clear()`.
- Changed "occurrence" terminology to "step".
- New methods added to `PathHandleGraph` to check path circularity and in `MutablePathHandleGraph` to set path circularity.
- Added a past-the-last iterator concept for `step_handle_t`, to be returned by `path_end()` and by `get_next_step()` when the argument is the final step.
- Updated documentation indicating that circular paths should loop around with `get_next_step` and  `get_previous_step`.
- A class `PathForEachSocket` that can socket from a `path_handle_t` to a C++ foreach loop over `handle_t`. 

One thing that we discussed doing that I did not do is add reverse iterators. I can also only guarantee that this compiles. It might not work once we link against it, but we need to put something up here to program against before I can really test it. 

Any comments before this API becomes VG law? @ekg @glennhickey @adamnovak