### PR TITLE
Proposal for modified interface to do reverse iteration on paths

### DIFF
--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -48,7 +48,7 @@ public:
     virtual std::string get_sequence(const handle_t& handle) const = 0;
     
     /// Return the number of nodes in the graph
-    virtual size_t node_size() const = 0;
+    virtual size_t get_node_count() const = 0;
     
     /// Return the smallest ID in the graph, or some smaller number if the
     /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
@@ -88,32 +88,9 @@ public:
     
     
     ////////////////////////////////////////////////////////////////////////////
-    // Backing protected virtual methods that need to be implemented
-    ////////////////////////////////////////////////////////////////////////////
-    
-protected:
-    
-    /// Loop over all the handles to next/previous (right/left) nodes. Passes
-    /// them to a callback which returns false to stop iterating and true to
-    /// continue. Returns true if we finished and false if we stopped early.
-    virtual bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const = 0;
-    
-    /// Loop over all the nodes in the graph in their local forward
-    /// orientations, in their internal stored order. Stop if the iteratee
-    /// returns false. Can be told to run in parallel, in which case stopping
-    /// after a false return value is on a best-effort basis and iteration
-    /// order is not defined. Returns true if we finished and false if we 
-    /// stopped early.
-    virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const = 0;
-    
-
-    
-    ////////////////////////////////////////////////////////////////////////////
     // Additional optional interface with a default implementation
     ////////////////////////////////////////////////////////////////////////////
-    
-public:
-    
+        
     /// Get the number of edges on the right (go_left = false) or left (go_left
     /// = true) side of the given handle. The default implementation is O(n) in
     /// the number of edges returned, but graph implementations that track this
@@ -137,6 +114,7 @@ public:
     /// Returns a substring of a handle's sequence, in the orientation of the
     /// handle. If the indicated substring would extend beyond the end of the
     /// handle's sequence, the return value is truncated to the sequence's end.
+    /// By default O(n) in the size of the handle's sequence, but can be overriden.
     virtual std::string get_subsequence(const handle_t& handle, size_t index, size_t size) const;
     
     ////////////////////////////////////////////////////////////////////////////
@@ -161,6 +139,26 @@ public:
     /// in parallel (parallel = true), stopping early is best-effort.
     template<typename Iteratee>
     bool for_each_edge(const Iteratee& iteratee, bool parallel = false) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Backing protected virtual methods that need to be implemented
+    ////////////////////////////////////////////////////////////////////////////
+    
+protected:
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    virtual bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const = 0;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined. Returns true if we finished and false if we 
+    /// stopped early.
+    virtual bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const = 0;
+    
     
 };
 

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -61,13 +61,13 @@ public:
     
     /// Get a handle to the last step, which will be an arbitrary step in a circular path that
     /// we consider "last" based on our construction of the path. If the path is empty
-    /// then the implementation must return the same value as path_rend().
-    virtual step_handle_t path_rbegin(const path_handle_t& path_handle) const = 0;
+    /// then the implementation must return the same value as path_front_end().
+    virtual step_handle_t path_back(const path_handle_t& path_handle) const = 0;
     
     /// Get a handle to a fictitious position before the beginning of a path. This position is
     /// return by get_previous_step for the first step in a path in a non-circular path.
     /// Note: get_previous_step will *NEVER* return this value for a circular path.
-    virtual step_handle_t path_rend(const path_handle_t& path_handle) const = 0;
+    virtual step_handle_t path_front_end(const path_handle_t& path_handle) const = 0;
 
     /// Returns true if the step is not the last step in a non-circular path.
     virtual bool has_next_step(const step_handle_t& step_handle) const = 0;

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -171,21 +171,17 @@ bool PathHandleGraph::for_each_step_in_path(const path_handle_t& path, const Ite
     auto wrapped = BoolReturningWrapper<Iteratee, step_handle_t>::wrap(iteratee);
 
     // We break in the case that the path is empty
-    if (get_step_count(path) == 0) return false;
+    if (get_step_count(path) == 0) return true;
     // Otherwise the path is nonempty so it is safe to try and grab a first step
     
-    // Get the value that the step should be when we are done
-    auto end = get_is_circular(path) ? path_begin(path) : path_end(path);
-    
-    // We might need to ignore the fact that we meet the ending condition in the first
-    // iteration on non-empty circular paths
-    bool ignore_end = !is_empty(path) && get_is_circular(path);
+    // Get the value that the step should be in the final iteration
+    auto end = path_back(path);
     
     // Allow the iteratee to set a bail-out condition
     bool keep_going = true;
-    for (auto here = path_begin(path); keep_going && (ignore_end || here != end); here = get_next_step(here)) {
+    for (auto here = path_begin(path); keep_going; here = get_next_step(here)) {
         // Execute the iteratee on this step
-        keep_going &= wrapped(here);
+        keep_going &= wrapped(here) && here != end;
         
     }
     


### PR DESCRIPTION
This is my proposal to address the concerns I noted in the discussion on https://github.com/vgteam/libhandlegraph/pull/13. Changes include:
- Renamed methods to use a terminology to refer to the endpoints of paths that I think is more internally consistent as well as more consistent with the STL (`path_begin` / `path_end` / `path_rbegin` / `path_rend`)
- Reverted the stock implementation of `for_each_step_in_path`. I'm willing to be convinced otherwise, but it really looked to me that the new edits were broken and would result in an infinite loop on circular paths.
- Updated the documentation to be (in my estimation) more unambiguous and specific.

I think the confusion we're having might be partly due to differences of opinion on what the iteration should be doing on circular paths. I wrote it so that you could in principle loop around a circular path forever. That is, the end of the path will loop around to the beginning when you call `get_next_step`. Do we all agree that this is the correct behavior?