### PR TITLE
Proposal for a serialization interface

### DIFF
--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -27,13 +27,13 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     
     /// Write the contents of this graph to an ostream.
-    virtual void serialize(ostream& out) const = 0;
+    virtual void serialize(std::ostream& out) const = 0;
     
     /// Sets the contents of this graph to the contents of a serialized graph from
     /// an istream. The serialized graph must be from the same implementation of the
     /// HandleGraph interface as is calling deserialize(). Can only be called by an
     /// empty graph.
-    virtual void deserialize(istream& in) = 0;
+    virtual void deserialize(std::istream& in) = 0;
    
     /// Method to check if a node exists by ID
     virtual bool has_node(nid_t node_id) const = 0;

--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -25,15 +25,6 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // Interface that needs to be implemented
     ////////////////////////////////////////////////////////////////////////////
-    
-    /// Write the contents of this graph to an ostream.
-    virtual void serialize(std::ostream& out) const = 0;
-    
-    /// Sets the contents of this graph to the contents of a serialized graph from
-    /// an istream. The serialized graph must be from the same implementation of the
-    /// HandleGraph interface as is calling deserialize(). Can only be called by an
-    /// empty graph.
-    virtual void deserialize(std::istream& in) = 0;
    
     /// Method to check if a node exists by ID
     virtual bool has_node(nid_t node_id) const = 0;
@@ -172,6 +163,20 @@ public:
     template<typename Iteratee>
     bool for_each_edge(const Iteratee& iteratee, bool parallel = false) const;
     
+};
+    
+class SerializableHandleGraph {
+    
+public:
+    
+    /// Write the contents of this graph to an ostream.
+    virtual void serialize(std::ostream& out) const = 0;
+    
+    /// Sets the contents of this graph to the contents of a serialized graph from
+    /// an istream. The serialized graph must be from the same implementation of the
+    /// HandleGraph interface as is calling deserialize(). Can only be called by an
+    /// empty graph.
+    virtual void deserialize(std::istream& in) = 0;
 };
 
 

--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -10,6 +10,7 @@
 
 #include <functional>
 #include <string>
+#include <iostream>
 
 namespace handlegraph {
 
@@ -24,6 +25,15 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // Interface that needs to be implemented
     ////////////////////////////////////////////////////////////////////////////
+    
+    /// Write the contents of this graph to an ostream.
+    virtual void serialize(ostream& out) const = 0;
+    
+    /// Sets the contents of this graph to the contents of a serialized graph from
+    /// an istream. The serialized graph must be from the same implementation of the
+    /// HandleGraph interface as is calling deserialize(). Can only be called by an
+    /// empty graph.
+    virtual void deserialize(istream& in) = 0;
    
     /// Method to check if a node exists by ID
     virtual bool has_node(nid_t node_id) const = 0;


### PR DESCRIPTION
Here's my proposal for a serialization/deserialization scheme.

I put it in a separate class for now, but I think the right way to do this is with one of @adamnovak 's HandleGraph traits. As such, I'm not going to bother working it into the class hierarchy. I also considered putting these methods in the base `HandleGraph`, but there are things like overlays that we don't care to have serialization methods for.

One thing I wish I could do here is to include a virtual constructor like:
```
class HandleGraph {
    virtual HandleGraph(std::istream& in) = 0;
};
```
Anyway, turns out virtual constructors prohibited in C++. I opted to have a `deserialize` method instead, but I don't love that this more or less requires you to first construct an empty graph and then deserialize in two distinct steps.