### PR TITLE
Copy method

### DIFF
--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -1,5 +1,7 @@
 #include "handlegraph/handle_graph.hpp"
 #include "handlegraph/path_handle_graph.hpp"
+#include "handlegraph/deletable_handle_graph.hpp"
+#include "handlegraph/mutable_path_deletable_handle_graph.hpp"
 #include "handlegraph/util.hpp"
 
 #include <vector>
@@ -169,6 +171,46 @@ bool operator==(const step_handle_t& a, const step_handle_t& b) {
 /// Define inequality on step handles
 bool operator!=(const step_handle_t& a, const step_handle_t& b) {
     return !(a == b);
+}
+
+/// Copy a Handle Graph into a Mutable Handle Graph
+void MutableHandleGraph::copy(const HandleGraph* other) {
+    assert(get_node_count() == 0);
+
+    other->for_each_handle([&](const handle_t& handle) {
+            create_handle(other->get_sequence(handle), other->get_id(handle));
+        });
+
+    other->for_each_edge([&](const edge_t& edge) {
+            create_edge(edge.first, edge.second);
+        });
+}
+
+/// Copy Handle Graph into a Deletable Handle Graph
+void DeletableHandleGraph::copy(const HandleGraph* other) {
+    clear();
+    MutableHandleGraph::copy(other);
+}
+
+/// Copy a Path Handle Graph into a Mutable Path Handle Graph
+void MutablePathMutableHandleGraph::copy(const PathHandleGraph* other) {
+    assert(get_path_count() == 0);
+
+    MutableHandleGraph::copy(other);
+    
+    other->for_each_path_handle([&](const path_handle_t& path_handle) {
+            path_handle_t new_path_handle = create_path_handle(other->get_path_name(path_handle),
+                                                               other->get_is_circular(path_handle));
+            other->for_each_step_in_path(path_handle, [&](const step_handle_t& step_handle) {
+                    append_step(new_path_handle, other->get_handle_of_step(step_handle));
+                });
+        });
+}
+
+/// Copy a Path Handle Graph into a Deletable Path Handle Graph
+void MutablePathDeletableHandleGraph::copy(const PathHandleGraph* other) {
+    clear();
+    MutablePathMutableHandleGraph::copy(other);
 }
 
 }

--- a/src/include/handlegraph/deletable_handle_graph.hpp
+++ b/src/include/handlegraph/deletable_handle_graph.hpp
@@ -36,6 +36,10 @@ public:
     
     /// Remove all nodes and edges.
     virtual void clear() = 0;
+
+    /// Copy over another graph.  Only valid if *this* is an empty graph
+    virtual void copy(const HandleGraph* other);
+
 };
 
 }

--- a/src/include/handlegraph/mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_handle_graph.hpp
@@ -72,6 +72,9 @@ public:
     /// This may be a no-op in the case of graph implementations that do not have any mechanism to maintain an ordering.
     virtual void apply_ordering(const std::vector<handle_t>& order, bool compact_ids = false) = 0;
 
+    /// Copy over another graph.  Only valid if *this is an empty graph
+    virtual void copy(const HandleGraph* other);
+
 };
 
 }

--- a/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
@@ -16,8 +16,13 @@ namespace handlegraph {
  */
 class MutablePathDeletableHandleGraph : virtual public MutablePathMutableHandleGraph, virtual public DeletableHandleGraph {
     
-    // No extra methods. Deleting a node or edge that is contained in a path is undefined behavior.
+    // Few extra methods. Deleting a node or edge that is contained in a path is undefined behavior.
     // The method clear() is now assumed to delete paths as well as nodes and edges.
+
+public:
+
+    /// Copy over another graph.  Only valid if *this is an empty graph
+    virtual void copy(const PathHandleGraph* other);
 };
 
 }

--- a/src/include/handlegraph/mutable_path_mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_mutable_handle_graph.hpp
@@ -15,13 +15,18 @@ namespace handlegraph {
  */
 class MutablePathMutableHandleGraph : virtual public MutablePathHandleGraph, virtual public MutableHandleGraph {
     
-    // No extra methods. However, some additional semantics are assumed:
+    // Few extra methods. However, some additional semantics are assumed:
     // - divide_handle() replaces every occurrence of the original handle with its subsegments
     //   in all stesps on all paths.
     // - apply_orientation() also applies the orientation to all occurrences of the handle
     //   in all paths.
     // - optimize() may also optimize the representation of paths, and if it reassigns node
     //   IDs the paths will be preserved with the new IDs.
+
+public:
+    
+    /// Copy over another graph.  Only valid if *this is an empty graph
+    virtual void copy(const PathHandleGraph* other);
     
 };
 


### PR DESCRIPTION
Adding `copy()` method.   This is to be able to convert from one graph implementation to another.  

(I previously pushed this to master due to git failure.  Reverted that and am PRing the reversion of reversion).

Is there laready a CLI for converting one graph to another?  If not, how are people testing?  I have a `vg convert` in a local branch of vg (using this libhandlegraph) that I will PR as a strawman, but I think this would eventually belong in sglib