### PR TITLE
set a node id increment hint

### DIFF
--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -60,6 +60,10 @@ public:
     /// Return the largest ID in the graph, or some larger number if the
     /// largest ID is unavailable. Return value is unspecified if the graph is empty.
     virtual nid_t max_node_id() const = 0;
+
+    /// Set a minimum id to increment the id space by, used as a hint during construction.
+    /// May have no effect on a backing implementation.
+    virtual void set_id_increment(const nid_t& min_id) = 0;
     
     ////////////////////////////////////////////////////////////////////////////
     // Stock interface that uses backing virtual methods

--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -61,10 +61,6 @@ public:
     /// largest ID is unavailable. Return value is unspecified if the graph is empty.
     virtual nid_t max_node_id() const = 0;
 
-    /// Set a minimum id to increment the id space by, used as a hint during construction.
-    /// May have no effect on a backing implementation.
-    virtual void set_id_increment(const nid_t& min_id) = 0;
-    
     ////////////////////////////////////////////////////////////////////////////
     // Stock interface that uses backing virtual methods
     ////////////////////////////////////////////////////////////////////////////

--- a/src/include/handlegraph/mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_handle_graph.hpp
@@ -74,6 +74,10 @@ public:
     /// This may be a no-op in the case of graph implementations that do not have any mechanism to maintain an ordering.
     virtual void apply_ordering(const std::vector<handle_t>& order, bool compact_ids = false) = 0;
 
+    /// Set a minimum id to increment the id space by, used as a hint during construction.
+    /// May have no effect on a backing implementation.
+    virtual void set_id_increment(const nid_t& min_id) = 0;
+
 };
 
 }


### PR DESCRIPTION
@jeizenga this is what I was talking about doing to make it so we can have a generic from-GFA loader algorithm that works on models (just odgi for now) that need to know the minimum node id in order to build an efficient in-memory model.

What do you think? Is there a better way to do this? I can also just hack this into odgi and we can give it custom loading code for our tests. That might be better.