### PR TITLE
Add increment_node_ids method to mutable handle graph

### DIFF
--- a/src/include/handlegraph/mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_handle_graph.hpp
@@ -78,6 +78,8 @@ public:
     /// May have no effect on a backing implementation.
     virtual void set_id_increment(const nid_t& min_id) = 0;
 
+    /// Add the given value to all node IDs
+    virtual void increment_node_ids(nid_t increment) = 0;
 };
 
 }


### PR DESCRIPTION
This is required to handlify `vg ids -j`