### PR TITLE
Add overridable methods for total edges and total length

### DIFF
--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -73,6 +73,22 @@ bool HandleGraph::has_edge(const handle_t& left, const handle_t& right) const {
     return !not_seen;
 }
 
+size_t HandleGraph::get_edge_count() const {
+    size_t total = 0;
+    for_each_edge([&](const edge_t& ignored) {
+        total++;
+    });
+    return total;
+};
+
+size_t HandleGraph::get_total_length() const {
+    size_t total = 0;
+    for_each_handle([&](const handle_t& h) {
+        total += get_length(h);
+    });
+    return total;
+};
+
 char HandleGraph::get_base(const handle_t& handle, size_t index) const {
     return get_sequence(handle)[index];
 }

--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -110,6 +110,14 @@ public:
         return has_edge(edge.first, edge.second);
     }
     
+    /// Return the total number of edges in the graph. If not overridden,
+    /// counts them all in linear time.
+    virtual size_t get_edge_count() const;
+    
+    /// Return the total length of all nodes in the graph, in bp. If not
+    /// overridden, loops over all nodes in linear time.
+    virtual size_t get_total_length() const;
+    
     /// Returns one base of a handle's sequence, in the orientation of the
     /// handle.
     virtual char get_base(const handle_t& handle, size_t index) const;


### PR DESCRIPTION
Some implementations (vg, xg) internally know how many edges and/or bases are in the graph. This adds methods that can be used to ask those questions, with default implementations that do linear scans through the basic handle API.