### PR TITLE
Use library name in include to not upset Binder

### DIFF
--- a/src/include/handlegraph/expanding_overlay_graph.hpp
+++ b/src/include/handlegraph/expanding_overlay_graph.hpp
@@ -5,7 +5,7 @@
  * Defines an interface for overlay graphs that duplicate underlying graph nodes.
  */
  
-#include "handle_graph.hpp"
+#include "handlegraph/handle_graph.hpp"
 
 namespace handlegraph {
 


### PR DESCRIPTION
The libbdsg binding build process doesn't want to deal with includes relative to the current directory.