### PR TITLE
Allow for portable and useful Python bindings

### DIFF
--- a/src/include/handlegraph/serializable_handle_graph.hpp
+++ b/src/include/handlegraph/serializable_handle_graph.hpp
@@ -69,7 +69,7 @@ inline void SerializableHandleGraph::serialize(std::ostream& out) const {
 }
 
 inline void SerializableHandleGraph::serialize(const std::string& filename) const {
-    ofstream out(filename);
+    std::ofstream out(filename);
     serialize(out);
 }
 
@@ -103,7 +103,7 @@ inline void SerializableHandleGraph::deserialize(std::istream& in) {
 }
 
 inline void SerializableHandleGraph::deserialize(const std::string& filename) const {
-    ifstream in(filename);
+    std::ifstream in(filename);
     deserialize(in);
 }
 

--- a/src/include/handlegraph/serializable_handle_graph.hpp
+++ b/src/include/handlegraph/serializable_handle_graph.hpp
@@ -42,7 +42,7 @@ public:
     /// a file. The serialized graph must be from the same implementation of the
     /// HandleGraph interface as is calling deserialize(). Can only be called on an
     /// empty graph.
-    inline void deserialize(const std::string& filename) const;
+    inline void deserialize(const std::string& filename);
         
 protected:
 
@@ -102,7 +102,7 @@ inline void SerializableHandleGraph::deserialize(std::istream& in) {
     deserialize_members(in);
 }
 
-inline void SerializableHandleGraph::deserialize(const std::string& filename) const {
+inline void SerializableHandleGraph::deserialize(const std::string& filename) {
     std::ifstream in(filename);
     deserialize(in);
 }

--- a/src/include/handlegraph/serializable_handle_graph.hpp
+++ b/src/include/handlegraph/serializable_handle_graph.hpp
@@ -6,6 +6,7 @@
  */
 
 #include <iostream>
+#include <fstream>
 #include <arpa/inet.h>
 
 namespace handlegraph {
@@ -28,12 +29,20 @@ public:
     /// Write the contents of this graph to an ostream. Makes sure to include a
     /// leading magic number.
     inline void serialize(std::ostream& out) const;
+    /// Write the contents of this graph to a named file. Makes sure to include
+    /// a leading magic number.
+    inline void serialize(const std::string& filename) const;
     
     /// Sets the contents of this graph to the contents of a serialized graph from
     /// an istream. The serialized graph must be from the same implementation of the
     /// HandleGraph interface as is calling deserialize(). Can only be called on an
     /// empty graph.
     inline void deserialize(std::istream& in);
+    /// Sets the contents of this graph to the contents of a serialized graph from
+    /// a file. The serialized graph must be from the same implementation of the
+    /// HandleGraph interface as is calling deserialize(). Can only be called on an
+    /// empty graph.
+    inline void deserialize(const std::string& filename) const;
         
 protected:
 
@@ -57,6 +66,11 @@ inline void SerializableHandleGraph::serialize(std::ostream& out) const {
     uint32_t magic_number = htonl(get_magic_number());
     out.write((char*) &magic_number, sizeof(magic_number) / sizeof(char));
     serialize_members(out);
+}
+
+inline void SerializableHandleGraph::serialize(const std::string& filename) const {
+    ofstream out(filename);
+    serialize(out);
 }
 
 inline void SerializableHandleGraph::deserialize(std::istream& in) {
@@ -87,6 +101,12 @@ inline void SerializableHandleGraph::deserialize(std::istream& in) {
     }
     deserialize_members(in);
 }
+
+inline void SerializableHandleGraph::deserialize(const std::string& filename) const {
+    ifstream in(filename);
+    deserialize(in);
+}
+
 }
 
 #endif

--- a/src/include/handlegraph/types.hpp
+++ b/src/include/handlegraph/types.hpp
@@ -8,11 +8,18 @@
 #include <cstdint>
 #include <utility>
 #include <functional>
+#include <limits>
 
 namespace handlegraph {
 
-/// Represents an id
-typedef int64_t nid_t;
+/// Represents an id.
+/// We use "long long int" here so that we resolve to a consistent C-level type across platforms.
+/// On Mac, int64_t is "long long" while on Linux it is just "long", and
+/// generated code that resolves all typedefs (i.e. Python bindings) is thus
+/// not portable between them if we use int64_t.
+typedef long long int nid_t;
+static_assert(std::numeric_limits<nid_t>::digits == std::numeric_limits<int64_t>::digits);
+
     
 [[deprecated("id_t collides with a standard type, use nid_t instead")]]
 typedef nid_t id_t;

--- a/src/include/handlegraph/types.hpp
+++ b/src/include/handlegraph/types.hpp
@@ -18,7 +18,7 @@ namespace handlegraph {
 /// generated code that resolves all typedefs (i.e. Python bindings) is thus
 /// not portable between them if we use int64_t.
 typedef long long int nid_t;
-static_assert(std::numeric_limits<nid_t>::digits == std::numeric_limits<int64_t>::digits);
+static_assert(std::numeric_limits<nid_t>::digits == std::numeric_limits<int64_t>::digits, "Can only build on a system where long long int is 64 bits");
 
     
 [[deprecated("id_t collides with a standard type, use nid_t instead")]]


### PR DESCRIPTION
This makes sure to remove non-fixed types like int64_t from the public interface (so Python bindings generated with Binder can be portable) and also adds serialization and deserialization with filenames (so languages that can't work with C++ streams can load and save graphs).