### PR TITLE
Set up absolute install_name for Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,14 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g")
 # The following folder will be included
 include_directories("src/include")
 
+# Don't use @rpath in Mac builds' install_name fields (AKA LC_ID_DYLIB in otool
+# -l output). Populate with an absolute path instead. This will let us actually
+# find the library when we use it as a CMake external project and don't fully
+# install it to any normal lib directory.
+set (CMAKE_MACOSX_RPATH OFF)
+# The install_name gets modified on installation to be this.
+set (CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
 add_library(handlegraph_objs OBJECT
   src/handle.cpp
   src/include/handlegraph/handle_graph.hpp


### PR DESCRIPTION
We need this for the libbdsg Python bindings to work out of the box on Mac. They build but don't actually install libhandlegraph.