### PR TITLE
Add RankedHandleGraph with just a node/handle ordering

### DIFF
--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -98,6 +98,20 @@ std::string HandleGraph::get_subsequence(const handle_t& handle, size_t index, s
     return get_sequence(handle).substr(index, size);
 }
 
+/// Return the rank of a handle (ranks start at 1 and are dense, and each
+/// orientation has its own rank). Handle ranks may not have anything to do
+/// with node ranks.
+size_t RankedHandleGraph::handle_to_rank(const handle_t& handle) const {
+    // Display all the orientations forward then reverse, in node order, starting at 1.
+    return id_to_rank(get_id(handle)) * 2 - 1 + (size_t) get_is_reverse(handle);
+}
+
+/// Return the handle with a given rank.
+handle_t RankedHandleGraph::rank_to_handle(const size_t& rank) const {
+    // 1 and 2 are node rank 0 forward and reverse, 3 and 4 are node rank 1 forward and reverse, etc.
+    return get_handle(rank_to_id((rank - 1)/2 + 1), rank % 2 == 0);
+}
+
 void MutableHandleGraph::increment_node_ids(nid_t increment) {
     // Increment IDs by just reassigning IDs and applying the increment as the ID translation
     reassign_node_ids([&](const nid_t& old_id) -> nid_t {

--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -173,11 +173,38 @@ protected:
     
 };
 
-/*
+/**
+ * Defines an interface for a handle graph that can rank its nodes and handles.
+ *
+ * Doesn't actually require an efficient node lookup by sequence position as in
+ * VectorizableHandleGraph.
+ */
+class RankedHandleGraph : virtual public HandleGraph {
+public:
+
+    /// Return the rank of a node (ranks start at 1 and are dense).
+    virtual size_t id_to_rank(const nid_t& node_id) const = 0;
+
+    /// Return the node with a given rank.
+    virtual nid_t rank_to_id(const size_t& rank) const = 0;
+    
+    // If you define node ID ranks you get a default implementation of handle ranks.
+    
+    /// Return the rank of a handle (ranks start at 1 and are dense, and each
+    /// orientation has its own rank). Handle ranks may not have anything to do
+    /// with node ranks.
+    virtual size_t handle_to_rank(const handle_t& handle) const;
+
+    /// Return the handle with a given rank.
+    virtual handle_t rank_to_handle(const size_t& rank) const;
+
+};
+
+/**
  * Defines an interface providing a vectorization of the graph nodes and edges,
  * which can be co-inherited alongside HandleGraph.
  */
-class VectorizableHandleGraph {
+class VectorizableHandleGraph : virtual public RankedHandleGraph {
 
 public:
 
@@ -192,12 +219,6 @@ public:
 
     /// Return a unique index among edges in the graph
     virtual size_t edge_index(const edge_t& edge) const = 0;
-
-    /// Return the rank of a node (ranks start at 1)
-    virtual size_t id_to_rank(const nid_t& node_id) const = 0;
-
-    /// Return the node with a given rank
-    virtual nid_t rank_to_id(const size_t& rank) const = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This also causes VectorizableHandleGraph (via RankedHandleGraph) to actually be a HandleGraph, so you can ask for a VectorizableHandleGraph or RankedHandleGraph if you want to guarantee you have a whole graph with those operations available. This in turn lets you make fewer duplicate overlays.