### PR TITLE
Add a truncate method with a default implementation to DeletableHandleGraph interface

### DIFF
--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -1,5 +1,6 @@
 #include "handlegraph/handle_graph.hpp"
 #include "handlegraph/mutable_handle_graph.hpp"
+#include "handlegraph/deletable_handle_graph.hpp"
 #include "handlegraph/path_handle_graph.hpp"
 #include "handlegraph/path_position_handle_graph.hpp"
 #include "handlegraph/util.hpp"
@@ -121,6 +122,18 @@ void MutableHandleGraph::increment_node_ids(nid_t increment) {
 
 void MutableHandleGraph::increment_node_ids(long increment) {
     increment_node_ids((nid_t)increment);
+}
+
+handle_t DeletableHandleGraph::truncate_handle(const handle_t& handle, bool trunc_left, size_t offset) {
+    auto halves = divide_handle(handle, offset);
+    if (trunc_left) {
+        destroy_handle(halves.first);
+        return halves.second;
+    }
+    else {
+        destroy_handle(halves.second);
+        return halves.first;
+    }
 }
 
 std::vector<step_handle_t> PathHandleGraph::steps_of_handle(const handle_t& handle,

--- a/src/include/handlegraph/deletable_handle_graph.hpp
+++ b/src/include/handlegraph/deletable_handle_graph.hpp
@@ -35,6 +35,12 @@ public:
     /// Does not update any stored paths.
     virtual void destroy_edge(const handle_t& left, const handle_t& right) = 0;
     
+    /// Shorten a node by truncating either the left or right side of the node, relative to the orientation
+    /// of the handle, starting from a given offset along the nodes sequence. Any edges on the truncated
+    /// end of the node are deleted. Returns a (possibly altered) handle to the truncated node.
+    /// May invalid stored paths.
+    virtual handle_t truncate_handle(const handle_t& handle, bool trunc_left, size_t offset);
+    
     /// Convenient wrapper for destroy_edge.
     inline void destroy_edge(const edge_t& edge) {
         destroy_edge(edge.first, edge.second);


### PR DESCRIPTION
The semantics are to remove one half of a node from a given offset. It can be accomplished by composing `divide_handle` with `destroy_handle`, but I want to have the option of a more efficient implementation as well.