### PR TITLE
Add a default implementation for handle get_step_count method

### DIFF
--- a/src/handle.cpp
+++ b/src/handle.cpp
@@ -150,6 +150,14 @@ std::vector<step_handle_t> PathHandleGraph::steps_of_handle(const handle_t& hand
     
     return found;
 }
+
+size_t PathHandleGraph::get_step_count(const handle_t& handle) const {
+    size_t count = 0;
+    for_each_step_on_handle(handle, [&](const step_handle_t& step) {
+        ++count;
+    });
+    return count;
+}
     
 bool PathHandleGraph::is_empty(const path_handle_t& path_handle) const {
     // By default, we can answer emptiness queries with the length query.

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -46,7 +46,7 @@ public:
     virtual size_t get_step_count(const path_handle_t& path_handle) const = 0;
 
     /// Returns the number of node steps on a handle
-    virtual size_t get_step_count(const handle_t& handle) const = 0;
+    virtual size_t get_step_count(const handle_t& handle) const;
     
     /// Get a node handle (node ID and orientation) from a handle to an step on a path
     virtual handle_t get_handle_of_step(const step_handle_t& step_handle) const = 0;


### PR DESCRIPTION
A new method `get_step_count` for a `handle_t` was added, but implementations weren't added elsewhere. This PR adds a default implementation based on `for_each_step_on_handle` so that things will keep running.