### PR TITLE
Const serialize

### DIFF
--- a/src/include/handlegraph/trivially_serializable.hpp
+++ b/src/include/handlegraph/trivially_serializable.hpp
@@ -56,11 +56,9 @@ public:
     // your own FD-to-C++-stream wrapper. We don't include one in
     // libhandlegraph to avoid dependencies and duplicate code with libvgio.
     
-    /// Write the contents of this object to an open file descriptor. Makes
-    /// sure to include a leading magic number.
-    ///
-    /// Assumes that the file entirely belongs to this object.
-    virtual void serialize(int fd) const = 0;
+    //Serialize as blocks of data shown to the given function. The pointer must not be null.
+    virtual void serialize(const std::function<void(const void*, size_t)>& iteratee) const = 0;
+    
     /// Write the contents of this object to an open file descriptor. Makes
     /// sure to include a leading magic number. If the file is a normal file,
     /// future modifications to the object will affect the file until
@@ -83,8 +81,14 @@ public:
     
     // Implementation doesn't need to provide anything below here; these all
     // call serialize_members() and deserialize_members(), or serialize(int)
-    // and deserialize(int) as appropriate. But they can still be overridden if
-    // needed.
+    // and deserialize(int), or serialize(function)  as appropriate. 
+    // But they can still be overridden if needed.
+
+    /// Write the contents of this object to an open file descriptor. Makes
+    /// sure to include a leading magic number.
+    ///
+    /// Assumes that the file entirely belongs to this object.
+    virtual void serialize(int fd) const;
 
     // Interface takes control of serialization to and from named files and
     // routes it through file descriptor functions.

--- a/src/include/handlegraph/trivially_serializable.hpp
+++ b/src/include/handlegraph/trivially_serializable.hpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 #include <limits>
+#include <functional>
 
 namespace handlegraph {
 

--- a/src/trivially_serializable.cpp
+++ b/src/trivially_serializable.cpp
@@ -17,6 +17,22 @@
  
 namespace handlegraph {
 
+void TriviallySerializeable::serialize(int fd) const {
+    serialize([&](const void* start, size_t length) {
+        // Copy each block to the fd
+        size_t written = 0;
+        while (written != length) {
+            // Bang on the write call until it is all written
+            auto result = write(fd, (const void*)((const char*) start + written), length - written);
+            if (result == -1) {
+                // Can't write at all, something broke.
+                throw std::runtime_error("Could not write!");
+            }
+            written += result;
+        }
+    });
+}
+
 void TriviallySerializable::serialize(std::ostream& out) const {
     if (out.rdbuf() == std::cout.rdbuf()) {
         // Assume we are using standard output

--- a/src/trivially_serializable.cpp
+++ b/src/trivially_serializable.cpp
@@ -17,7 +17,7 @@
  
 namespace handlegraph {
 
-void TriviallySerializeable::serialize(int fd) const {
+void TriviallySerializable::serialize(int fd) const {
     serialize([&](const void* start, size_t length) {
         // Copy each block to the fd
         size_t written = 0;


### PR DESCRIPTION
Require serialize-to-byte-range-views instead of a const serialize-to-fd from TriviallySerializable, and provide a default const serialize-to-fd implementation.