### PR TITLE
Hash net_handle_t values instead of addresses

### DIFF
--- a/src/include/handlegraph/types.hpp
+++ b/src/include/handlegraph/types.hpp
@@ -135,7 +135,7 @@ public:
 template<> struct hash<handlegraph::net_handle_t> {
 public:
     inline size_t operator()(const handlegraph::net_handle_t& net_handle) const {
-        return std::hash<uint64_t>()(reinterpret_cast<const uint64_t>(&net_handle));
+        return std::hash<uint64_t>()(reinterpret_cast<const uint64_t*>(&net_handle));
     }
 };
 


### PR DESCRIPTION
Looks like we dropped a `*` here.