### PR TITLE
Allow tracking nodes through chop

### DIFF
--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -850,6 +850,7 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                 originalRank = get<0>(originalRank_inChoppedNodeRank_handle[newRank]);
                 // Reset to offset 0.
                 offset = 0;
+                std::cerr << "Original rank " << originalRank << " starts at new rank " << newRank << std::endl;
                 revOffset = 0;
                 // And scan to the end of the original node to get our reverse
                 // strand offset and populate pieces.
@@ -861,8 +862,10 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                     // Until we hit a new node that belongs to a different old node, keep accumulating handles in pieces.
                     handle_t cursorHandle = get_handle_for_new_rank(nextOriginalStarts);
                     pieces.push_back(cursorHandle);
+                    std::cerr << "New rank " << nextOriginalStarts << " is new ID " << graph.get_id(cursorHandle) << std::endl;
                     // And add its length to the offset from the end of the original node
                     revOffset += graph.get_length(cursorHandle);
+                    std::cerr << "And has length " << graph.get_length(cursorHandle) << std::endl;
                     // Then look at the next new node.
                     nextOriginalStarts++;
                 }
@@ -871,6 +874,8 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                 originalSplit = (pieces.size() > 1);
             }
             
+            std::cerr << "So we're at offset " << offset << " forward and " << revOffset << " reverse for total original length " << (offset + revOffset) << std::endl;
+            
             // Then look at what's at the front of pieces, which is going to be us.
             handle_t newHandle = pieces.front();
             size_t length = graph.get_length(newHandle);
@@ -878,6 +883,8 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
             // Compute the right revOfset, which should no longer include our length.
             // Its loop invariant is weird to save a length check.
             revOffset -= length;
+            
+            std::cerr << "So we remove the " << length << " of node " << graph.get_id(newHandle) << " and we have a rev offset of " << revOffset << endl;
             
             if (idsChanged || originalSplit) {
                 // We are (probably) an important change.
@@ -888,6 +895,9 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
             
             // Update forward strand offset for next piece of original node
             offset += length;
+            
+            std::cerr << "And then we add it on the forward strand and we have a forward offset for the next node of " << offset << endl;
+            
             // And advance to next piece
             pieces.pop_front();
         }

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -873,16 +873,21 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
             
             // Then look at what's at the front of pieces, which is going to be us.
             handle_t newHandle = pieces.front();
+            size_t length = graph.get_length(newHandle);
+            
+            // Compute the right revOfset, which should no longer include our length.
+            // Its loop invariant is weird to save a length check.
+            revOffset -= length;
+            
             if (idsChanged || originalSplit) {
                 // We are (probably) an important change.
                 // TODO: Elide cases where IDs changed but this ID didn't.
                 // Announce a new node starting here
                 (*record_change)(originalId[originalRank], offset, revOffset, newHandle);
             }
-            // Update offsets for next piece of original node
-            size_t length = graph.get_length(newHandle);
+            
+            // Update forward strand offset for next piece of original node
             offset += length;
-            revOffset -= length;
             // And advance to next piece
             pieces.pop_front();
         }

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -821,6 +821,14 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
     }
 }
 
+void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length, const std::function<void(nid_t, size_t, nid_t)>& record_change) {
+    chop(graph, max_node_length, &record_changes);
+}
+
+void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length) {
+    chop(graph, max_node_length, nullptr);
+}
+
 
 }
 }

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -840,7 +840,6 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                 // Reset to offset 0.
                 offset = 0;
                 // And scan to the end of the original node to get our reverse strand offset and populate pieces.
-                revOffset = 0;
                 handle_t cursorHandle;
                 if (idsChanged) {
                     // Handles were invalidated but everything was renumbered by rank.
@@ -850,6 +849,10 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                     cursorHandle = get<2>(originalRank_inChoppedNodeRank_handle[newRank]);
                 }
                 pieces.push_back(cursorHandle);
+                // The reverse offset has to have the first handle's length in
+                // it, because the loop invariant is shifted to save a second
+                // length call on each subsequent loop.
+                revOffset = graph.get_length(cursorHandle);
                 size_t nextOriginalStarts = newRank + 1;
                 while (nextOriginalStarts < originalRank_inChoppedNodeRank_handle.size() && get<0>(originalRank_inChoppedNodeRank_handle[nextOriginalStarts]) == originalRank) {
                     // Until we hit a new node that belongs to a different old node, keep accumulating handles in pieces.

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -821,7 +821,7 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
             // So we need to walk them together and look at the node lengths, and generate calls to record_change for all the segments (or at least those that aren't full-length and changed number).
             size_t offset = 0;
             size_t prevOriginalRank = numeric_limits<size_t>::max();
-            for (size_t newRank = 0; newRank < originalRank_inChoppedNodeRank_handle.size() newRank++) {
+            for (size_t newRank = 0; newRank < originalRank_inChoppedNodeRank_handle.size(); newRank++) {
                 size_t originalRank = get<0>(originalRank_inChoppedNodeRank_handle[newRank]);
                 if (originalRank != prevOriginalRank) {
                     // Starting a new old node
@@ -831,7 +831,7 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                 // Handles we stored are invalidated, so get based on ID based on rank
                 handle_t newHandle = graph.get_handle((nid_t)(newRank + 1), false);
                 // Announce a new node starting here
-                record_change(originalId[originalRank], offset, graph.get_id(newHandle));
+                (*record_change)(originalId[originalRank], offset, graph.get_id(newHandle));
                 // Update offset for next piece of original node
                 offset += graph.get_length(newHandle);
             }
@@ -840,7 +840,7 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
             // TODO: combine into one loop? Or avoid visiting non-modified nodes?
             size_t offset = 0;
             size_t prevOriginalRank = numeric_limits<size_t>::max();
-            for (size_t newRank = 0; newRank < originalRank_inChoppedNodeRank_handle.size() newRank++) {
+            for (size_t newRank = 0; newRank < originalRank_inChoppedNodeRank_handle.size(); newRank++) {
                 size_t originalRank = get<0>(originalRank_inChoppedNodeRank_handle[newRank]);
                 if (originalRank != prevOriginalRank) {
                     // Starting a new old node
@@ -851,7 +851,7 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                 // For now just use the existing handles and log all the nodes.
                 handle_t newHandle = get<2>(originalRank_inChoppedNodeRank_handle[newRank]);
                 // Announce a new node starting here
-                record_change(originalId[originalRank], offset, graph.get_id(newHandle));
+                (*record_change)(originalId[originalRank], offset, graph.get_id(newHandle));
                 // Update offset for next piece of original node
                 offset += graph.get_length(newHandle);
             }

--- a/src/chop.cpp
+++ b/src/chop.cpp
@@ -850,7 +850,6 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                 originalRank = get<0>(originalRank_inChoppedNodeRank_handle[newRank]);
                 // Reset to offset 0.
                 offset = 0;
-                std::cerr << "Original rank " << originalRank << " starts at new rank " << newRank << std::endl;
                 revOffset = 0;
                 // And scan to the end of the original node to get our reverse
                 // strand offset and populate pieces.
@@ -862,10 +861,8 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                     // Until we hit a new node that belongs to a different old node, keep accumulating handles in pieces.
                     handle_t cursorHandle = get_handle_for_new_rank(nextOriginalStarts);
                     pieces.push_back(cursorHandle);
-                    std::cerr << "New rank " << nextOriginalStarts << " is new ID " << graph.get_id(cursorHandle) << std::endl;
                     // And add its length to the offset from the end of the original node
                     revOffset += graph.get_length(cursorHandle);
-                    std::cerr << "And has length " << graph.get_length(cursorHandle) << std::endl;
                     // Then look at the next new node.
                     nextOriginalStarts++;
                 }
@@ -874,8 +871,6 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
                 originalSplit = (pieces.size() > 1);
             }
             
-            std::cerr << "So we're at offset " << offset << " forward and " << revOffset << " reverse for total original length " << (offset + revOffset) << std::endl;
-            
             // Then look at what's at the front of pieces, which is going to be us.
             handle_t newHandle = pieces.front();
             size_t length = graph.get_length(newHandle);
@@ -883,8 +878,6 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
             // Compute the right revOfset, which should no longer include our length.
             // Its loop invariant is weird to save a length check.
             revOffset -= length;
-            
-            std::cerr << "So we remove the " << length << " of node " << graph.get_id(newHandle) << " and we have a rev offset of " << revOffset << endl;
             
             if (idsChanged || originalSplit) {
                 // We are (probably) an important change.
@@ -895,9 +888,6 @@ static void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length,
             
             // Update forward strand offset for next piece of original node
             offset += length;
-            
-            std::cerr << "And then we add it on the forward strand and we have a forward offset for the next node of " << offset << endl;
-            
             // And advance to next piece
             pieces.pop_front();
         }

--- a/src/include/handlegraph/algorithms/chop.hpp
+++ b/src/include/handlegraph/algorithms/chop.hpp
@@ -8,13 +8,32 @@ namespace algorithms {
 
 /**
  * Chop the graph so nodes are at most max_node_length. Preserves relative
- * ordering of node IDs.
+ * ordering of nodes, but may reassign IDs. Preserves local forward orientation
+ * of new pieces.
+ *
+ * Invalidates handles into the graph.
  */
 void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length);
 
 /**
+ * Chop the graph so nodes are at most max_node_length. Preserves relative
+ * ordering of nodes, but may reassign IDs. Preserves local forward orientation
+ * of new pieces.
+ *
+ * Invalidates handles into the graph.
+ *
+ * Call the given callback, if any nodes change ID or are divided, to describe
+ * where each new node ID starts on each old node ID. Passes (old node ID,
+ * start offset along old node, new node ID).
+ */
+void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length, const std::function<void(nid_t, size_t, nid_t)>& record_change);
+
+/**
  * Unchop by gluing abutting handles with just a single edge between them and
- * compatible path steps together. Preserves relative ordering of node IDs.
+ * compatible path steps together. Broadly preserves relative ordering of
+ * nodes.
+ *
+ * Invalidates handles into the graph.
  */
 void unchop(MutablePathDeletableHandleGraph& graph);
 

--- a/src/include/handlegraph/algorithms/chop.hpp
+++ b/src/include/handlegraph/algorithms/chop.hpp
@@ -23,10 +23,14 @@ void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length);
  * Invalidates handles into the graph.
  *
  * Call the given callback, if any nodes change ID or are divided, to describe
- * where each new node ID starts on each old node ID. Passes (old node ID,
- * start offset along old node, new node ID).
+ * where each new node starts on each old node ID. Passes (old node ID, start
+ * offset along old node forward strand, same for reverse strand, new node
+ * handle).
+ *
+ * During the callback, the new node will exist in the graph, while the old
+ * node may not.
  */
-void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length, const std::function<void(nid_t, size_t, nid_t)>& record_change);
+void chop(MutablePathDeletableHandleGraph& graph, size_t max_node_length, const std::function<void(nid_t, size_t, size_t, handle_t)>& record_change);
 
 /**
  * Unchop by gluing abutting handles with just a single edge between them and

--- a/src/include/handlegraph/mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_handle_graph.hpp
@@ -56,6 +56,7 @@ public:
     /// handles come in the order and orientation appropriate for the handle
     /// passed in.
     /// Updates stored paths.
+    /// This invalidates the passed handles, but not other handles.
     virtual std::vector<handle_t> divide_handle(const handle_t& handle, const std::vector<size_t>& offsets) = 0;
     
     /// Specialization of divide_handle for a single division point
@@ -69,13 +70,17 @@ public:
     /// performance.
     /// Note: Ideally, this method is called one time once there is expected to be
     /// few graph modifications in the future.
+    /// This may invalidate outstanding handles.
     virtual void optimize(bool allow_id_reassignment = true) = 0;
 
     /// Reorder the graph's internal structure to match that given.
     /// This sets the order that is used for iteration in functions like for_each_handle.
-    /// Optionally may compact the id space of the graph to match the ordering, from 1->|ordering|.
+    /// If compact_ids is true, may (but will not necessarily) compact the id space of the graph to match the ordering, from 1->|ordering|.
+    /// In other cases, node IDs will be preserved.
     /// This may be a no-op in the case of graph implementations that do not have any mechanism to maintain an ordering.
-    virtual void apply_ordering(const std::vector<handle_t>& order, bool compact_ids = false) = 0;
+    /// This may invalidate outstanding handles.
+    /// Returns true if node IDs actually were adjusted to match the given order, and false if they remain unchanged.
+    virtual bool apply_ordering(const std::vector<handle_t>& order, bool compact_ids = false) = 0;
 
     /// Set a minimum id to increment the id space by, used as a hint during construction.
     /// May have no effect on a backing implementation.


### PR DESCRIPTION
This adds machinery we need to track nodes through `vg chop`. vg will need this for GFA-space compatibility.