### PR TITLE
Path metadata API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(handlegraph_objs OBJECT
   src/deletable_handle_graph.cpp
   src/handle_graph.cpp
   src/mutable_handle_graph.cpp
+  src/path_metadata.cpp
+  src/mutable_path_metadata.cpp 
   src/path_handle_graph.cpp 
   src/path_position_handle_graph.cpp
   src/mutable_path_handle_graph.cpp

--- a/src/copy_graph.cpp
+++ b/src/copy_graph.cpp
@@ -44,17 +44,26 @@ void copy_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandl
     //            throw runtime_error("error:[copy_handle_graph] cannot copy into a non-empty graph");
     //        }
     
-    // copy paths
-    from->for_each_path_handle([&](const path_handle_t& path_handle) {
-        copy_path(from, path_handle, into);
-    });
+    // For every sense of path
+    for (auto& sense : {PathMetadata::SENSE_REFERENCE, PathMetadata::SENSE_GENERIC, PathMetadata::SENSE_HAPLOTYPE}) {
+        // copy paths of that sense
+        from->for_each_path_of_sense(sense, [&](const path_handle_t& path_handle) {
+            copy_path(from, path_handle, into);
+        });
+    }
 }
 
 void copy_path(const PathHandleGraph* from, const path_handle_t& path,
                MutablePathHandleGraph* into) {
     
-    // init path
-    path_handle_t copied = into->create_path_handle(from->get_path_name(path), from->get_is_circular(path));
+    // We know that the new path metadata API is there, so use it
+    path_handle_t copied = into->create_path(from->get_sense(path),
+                                             from->get_sample_name(path),
+                                             from->get_locus_name(path),
+                                             from->get_haplotype(path),
+                                             from->get_phase_block(path),
+                                             from->get_subrange(path),
+                                             from->get_is_circular(path));
     
     // copy steps
     for (handle_t handle : from->scan_path(path)) {

--- a/src/include/handlegraph/mutable_path_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_handle_graph.hpp
@@ -6,6 +6,7 @@
  */
 
 #include "handlegraph/path_handle_graph.hpp"
+#include "handlegraph/mutable_path_metadata.hpp"
 
 namespace handlegraph {
 
@@ -16,7 +17,7 @@ namespace handlegraph {
  * MutablePathMutableHandleGraph interface.
  * TODO: This is a very limited interface at the moment. It will probably need to be extended.
  */
-class MutablePathHandleGraph : virtual public PathHandleGraph {
+class MutablePathHandleGraph : virtual public PathHandleGraph, virtual public MutablePathMetadata {
 public:
     
     virtual ~MutablePathHandleGraph() = default;

--- a/src/include/handlegraph/mutable_path_metadata.hpp
+++ b/src/include/handlegraph/mutable_path_metadata.hpp
@@ -19,7 +19,7 @@ namespace handlegraph {
  * a name-based create_path_handle() and special path name formatting.
  *
  */
-class MutablePathMetadata {
+class MutablePathMetadata : virtual public PathMetadata {
 public:
     
     virtual ~MutablePathMetadata() = default;
@@ -60,7 +60,19 @@ protected:
      */
     virtual path_handle_t create_path_handle(const std::string& name,
                                              bool is_circular = false) = 0;
-    
+                                             
+private:
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Internal machinery for path name mini-format
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Separator used to separate path name components
+    static const char SEPARATOR;
+    // Ranges are set off with some additional characters.
+    static const char RANGE_START_SEPARATOR;
+    static const char RANGE_END_SEPARATOR;
+    static const char RANGE_TERMINATOR;
     
 };
 

--- a/src/include/handlegraph/mutable_path_metadata.hpp
+++ b/src/include/handlegraph/mutable_path_metadata.hpp
@@ -1,0 +1,70 @@
+#ifndef HANDLEGRAPH_MUTABLE_PATH_METADATA_HPP_INCLUDED
+#define HANDLEGRAPH_MUTABLE_PATH_METADATA_HPP_INCLUDED
+
+/** \file 
+ * Defines the mutable metadata API for paths
+ */
+
+#include "handlegraph/path_metadata.hpp"
+
+#include <vector>
+
+namespace handlegraph {
+
+/**
+ * This is the interface for mutable embedded path and haplotype thread
+ * metadata (see PathMetadata).
+ *
+ * Comes with a default implementation of this interface, based on
+ * a name-based create_path_handle() and special path name formatting.
+ *
+ */
+class MutablePathMetadata {
+public:
+    
+    virtual ~MutablePathMetadata() = default;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Mutable path metadata interface that needs to be implemented
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /**
+     * Add a path with the given metadata. Any item can be the
+     *  corresponding unset sentinel (PathMetadata::NO_LOCUS_NAME, PathMetadata::NO_PHASE_BLOCK, etc.).
+     * 
+     *  Implementations may refuse to store paths-or-threads of certain senses
+     *  when relevant fields are unset.
+     * 
+     * Handles to other paths must
+     * remain valid.
+     */
+    virtual path_handle_t create_path(const PathMetadata::Sense& sense,
+                                      const std::string& sample,
+                                      const std::string& locus,
+                                      const int64_t& haplotype,
+                                      const int64_t& phase_block,
+                                      const std::pair<int64_t, int64_t>& subrange,
+                                      bool is_circular = false);
+
+protected:
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Backing methods for default implementation
+    ////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Create a path with the given name. The caller must ensure that no path
+     * with the given name exists already, or the behavior is undefined.
+     * Returns a handle to the created empty path. Handles to other paths must
+     * remain valid.
+     */
+    virtual path_handle_t create_path_handle(const std::string& name,
+                                             bool is_circular = false) = 0;
+    
+    
+};
+
+}
+
+#endif
+

--- a/src/include/handlegraph/mutable_path_metadata.hpp
+++ b/src/include/handlegraph/mutable_path_metadata.hpp
@@ -29,11 +29,12 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     
     /**
-     * Add a path with the given metadata. Any item can be the
-     *  corresponding unset sentinel (PathMetadata::NO_LOCUS_NAME, PathMetadata::NO_PHASE_BLOCK, etc.).
+     * Add a path with the given metadata. Any item can be the corresponding
+     * unset sentinel (PathMetadata::NO_LOCUS_NAME,
+     * PathMetadata::NO_PHASE_BLOCK, etc.).
      * 
-     *  Implementations may refuse to store paths-or-threads of certain senses
-     *  when relevant fields are unset.
+     * Implementations may refuse to store paths-or-threads of certain senses
+     * when relevant fields are unset.
      * 
      * Handles to other paths must
      * remain valid.
@@ -61,19 +62,6 @@ protected:
     virtual path_handle_t create_path_handle(const std::string& name,
                                              bool is_circular = false) = 0;
                                              
-private:
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Internal machinery for path name mini-format
-    ////////////////////////////////////////////////////////////////////////////
-
-    /// Separator used to separate path name components
-    static const char SEPARATOR;
-    // Ranges are set off with some additional characters.
-    static const char RANGE_START_SEPARATOR;
-    static const char RANGE_END_SEPARATOR;
-    static const char RANGE_TERMINATOR;
-    
 };
 
 }

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -98,12 +98,18 @@ public:
     /// Execute a function on each path_handle_t in the graph. If it returns bool, and
     /// it returns false, stop iteration. Returns true if we finished and false if we
     /// stopped early.
+    ///
+    /// If the graph contains compressed haplotype paths, they should not be
+    /// visible here. Only reference or generic named paths should be visible.
     template<typename Iteratee>
     bool for_each_path_handle(const Iteratee& iteratee) const;
     
     /// Execute a function on each step (step_handle_t) of a handle
     /// in any path. If it returns bool and returns false, stop iteration.
     /// Returns true if we finished and false if we stopped early.
+    ///
+    /// If the graph contains compressed haplotype paths, they should not be
+    /// visible here. Only reference or generic named paths should be visible.
     template<typename Iteratee>
     bool for_each_step_on_handle(const handle_t& handle, const Iteratee& iteratee) const;
     
@@ -115,11 +121,17 @@ protected:
     
     /// Execute a function on each path in the graph. If it returns false, stop
     /// iteration. Returns true if we finished and false if we stopped early.
+    ///
+    /// If the graph contains compressed haplotype paths, they should not be
+    /// visible here. Only reference or generic named paths should be visible.
     virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const = 0;
     
     /// Execute a function on each step of a handle in any path. If it
     /// returns false, stop iteration. Returns true if we finished and false if
     /// we stopped early.
+    ///
+    /// If the graph contains compressed haplotype paths, they should not be
+    /// visible here. Only reference or generic named paths should be visible.
     virtual bool for_each_step_on_handle_impl(const handle_t& handle,
         const std::function<bool(const step_handle_t&)>& iteratee) const = 0;
 

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -6,6 +6,7 @@
  */
 
 #include "handlegraph/handle_graph.hpp"
+#include "handlegraph/path_metadata.hpp"
 
 #include <vector>
 
@@ -17,7 +18,7 @@ class PathForEachSocket;
 /**
  * This is the interface for a handle graph that stores embedded paths.
  */
-class PathHandleGraph : virtual public HandleGraph {
+class PathHandleGraph : virtual public HandleGraph, virtual public PathMetadata {
 public:
     
     virtual ~PathHandleGraph() = default;
@@ -99,7 +100,8 @@ public:
     /// it returns false, stop iteration. Returns true if we finished and false if we
     /// stopped early.
     ///
-    /// If the graph contains compressed haplotype paths, they should not be
+    /// If the graph contains compressed haplotype paths and properly
+    /// implements for_each_path_of_sense to retrieve them, they should not be
     /// visible here. Only reference or generic named paths should be visible.
     template<typename Iteratee>
     bool for_each_path_handle(const Iteratee& iteratee) const;
@@ -108,7 +110,8 @@ public:
     /// in any path. If it returns bool and returns false, stop iteration.
     /// Returns true if we finished and false if we stopped early.
     ///
-    /// If the graph contains compressed haplotype paths, they should not be
+    /// If the graph contains compressed haplotype paths and properly
+    /// implements for_each_step_of_sense to find them, they should not be
     /// visible here. Only reference or generic named paths should be visible.
     template<typename Iteratee>
     bool for_each_step_on_handle(const handle_t& handle, const Iteratee& iteratee) const;
@@ -122,7 +125,8 @@ protected:
     /// Execute a function on each path in the graph. If it returns false, stop
     /// iteration. Returns true if we finished and false if we stopped early.
     ///
-    /// If the graph contains compressed haplotype paths, they should not be
+    /// If the graph contains compressed haplotype paths and properly
+    /// implements for_each_path_of_sense to retrieve them, they should not be
     /// visible here. Only reference or generic named paths should be visible.
     virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const = 0;
     
@@ -130,7 +134,8 @@ protected:
     /// returns false, stop iteration. Returns true if we finished and false if
     /// we stopped early.
     ///
-    /// If the graph contains compressed haplotype paths, they should not be
+    /// If the graph contains compressed haplotype paths and properly
+    /// implements for_each_step_of_sense to find them, they should not be
     /// visible here. Only reference or generic named paths should be visible.
     virtual bool for_each_step_on_handle_impl(const handle_t& handle,
         const std::function<bool(const step_handle_t&)>& iteratee) const = 0;

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -124,6 +124,11 @@ protected:
     // Backing protected virtual methods that have a default implementation
     ////////////////////////////////////////////////////////////////////////////
     
+    // The default implementations for these scanning methods falls back on the
+    // generic for_each_path_handle/for_each_step_on_handle and just filters.
+    // If those are implemented to elide haplotype paths, these need to be
+    // implemented to allow them to be retrieved.
+    
     /// Loop through all the paths with the given sense. Returns false and
     /// stops if the iteratee returns false.
     virtual bool for_each_path_of_sense_impl(const Sense& sense, const std::function<bool(const path_handle_t&)>& iteratee) const;
@@ -136,8 +141,31 @@ protected:
     // Backing methods that need to be implemented for default implementation
     ////////////////////////////////////////////////////////////////////////////
     
+    // These are really PathHandleGraph methods; we just have to know they exist
+    
     /// Look up the name of a path from a handle to it
     virtual std::string get_path_name(const path_handle_t& path_handle) const = 0;
+    
+    /// Returns a handle to the path that an step is on
+    virtual path_handle_t get_path_handle_of_step(const step_handle_t& step_handle) const = 0;
+    
+    /// Execute a function on each path in the graph. If it returns false, stop
+    /// iteration. Returns true if we finished and false if we stopped early.
+    ///
+    /// If the graph contains compressed haplotype paths and properly
+    /// implements for_each_path_of_sense to retrieve them, they should not be
+    /// visible here. Only reference or generic named paths should be visible.
+    virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const = 0;
+    
+    /// Execute a function on each step of a handle in any path. If it
+    /// returns false, stop iteration. Returns true if we finished and false if
+    /// we stopped early.
+    ///
+    /// If the graph contains compressed haplotype paths and properly
+    /// implements for_each_step_of_sense to find them, they should not be
+    /// visible here. Only reference or generic named paths should be visible.
+    virtual bool for_each_step_on_handle_impl(const handle_t& handle,
+        const std::function<bool(const step_handle_t&)>& iteratee) const = 0;
     
 private:
     
@@ -145,14 +173,6 @@ private:
     // Internal machinery for path name mini-format
     ////////////////////////////////////////////////////////////////////////////
     
-    /// Separator used to separate path name components
-    static const char SEPARATOR;
-    // Ranges are set off with some additional characters.
-    static const char RANGE_START_SEPARATOR;
-    static const char RANGE_END_SEPARATOR;
-    static const char RANGE_TERMINATOR;
-    
-    // And we use these for parsing
     static const std::regex FORMAT;
     static const size_t ASSEMBLY_OR_NAME_MATCH;
     static const size_t LOCUS_MATCH_WITHOUT_HAPLOTYPE;

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -1,0 +1,181 @@
+#ifndef HANDLEGRAPH_PATH_METADATA_HPP_INCLUDED
+#define HANDLEGRAPH_PATH_METADATA_HPP_INCLUDED
+
+/** \file 
+ * Defines the metadata API for paths
+ */
+
+#include "handlegraph/handle_graph.hpp"
+
+#include <utility>
+#include <string>
+#include <regex>
+
+namespace handlegraph {
+
+/**
+ * This is the interface for embedded path and haplotype thread metadata.
+ *
+ * Comes with a default implementation of this interface, based on
+ * a get_path_name() and special path name formatting.
+ *
+ * Our model is that paths come in different "senses":
+ *
+ * - SENSE_GENERIC: a generic named path. Has a "locus" name.
+ *
+ * - SENSE_REFERENCE: a part of a reference assembly. Has a "sample" name, a
+ *   "locus" name, and a haplotype number.
+ *
+ * - SENSE_HAPLOTYPE: a haplotype from a particular individual. Has a "sample"
+ *   name, a "locus" name, a haplotype number, and a phase block identifier.
+ *
+ * Paths of all sneses can represent subpaths, with bounds.
+ *
+ * Depending on sense, a path might have:
+ *
+ * - Sample: sample or assembly name.
+ *
+ * - Locus: contig, scaffold, or gene name path either represents in its
+ *   assembly or is an allele of in its sample.
+ *
+ * - Haplotype number: number identifying which haplotype of a locus is being
+ *   represented. GFA uses a convention where the presence of a haplotype 0
+ *   implies that only one haplotype is present.
+ *
+ * - Phase block identifier: Distinguishes fragments of a haplotype that are
+ *   phased but not necessarily part of a single self-consistent scaffold (often
+ *   due to self-contradictory VCF information). Must be unique within a sample,
+ *   locus, and haplotype. May be a number or a start coordinate.
+ *
+ * - Bounds, for when a path as stored gives only a sub-range of a conceptually
+ *   longer path. Multiple items can be stored with identical metadata in the
+ *   other fields if their bounds are non-overlapping.
+ * TODO: Interaction with phase block in GBWT???
+ */
+class PathMetadata {
+public:
+    
+    virtual ~PathMetadata() = default;
+    
+    /// Each path always has just one sense.
+    enum Sense {
+        SENSE_GENERIC,
+        SENSE_REFERENCE,
+        SENSE_HAPLOTYPE
+    };
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Path metadata interface that has a default implementation
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// What is the given path meant to be representing?
+    virtual Sense get_sense(const path_handle_t& handle) const;
+    
+    /// Get the name of the sample or assembly asociated with the
+    /// path-or-thread, or NO_SAMPLE_NAME if it does not belong to one.
+    virtual std::string get_sample_name(const path_handle_t& handle) const;
+    static const std::string NO_SAMPLE_NAME;
+    
+    /// Get the name of the contig or gene asociated with the path-or-thread,
+    /// or NO_LOCUS_NAME if it does not belong to one.
+    virtual std::string get_locus_name(const path_handle_t& handle) const;
+    static const std::string NO_LOCUS_NAME;
+    
+    /// Get the haplotype number (0 or 1, for diploid) of the path-or-thread,
+    /// or NO_HAPLOTYPE if it does not belong to one.
+    virtual int64_t get_haplotype(const path_handle_t& handle) const;
+    static const int64_t NO_HAPLOTYPE;
+    
+    /// Get the phase block number (contiguously phased region of a sample,
+    /// contig, and haplotype) of the path-or-thread, or NO_PHASE_BLOCK if it
+    /// does not belong to one.
+    virtual int64_t get_phase_block(const path_handle_t& handle) const;
+    static const int64_t NO_PHASE_BLOCK;
+    
+    /// Get the bounds of the path-or-thread that are actually represented
+    /// here. Should be NO_SUBRANGE if the entirety is represented here, and
+    /// 0-based inclusive start and exclusive end positions of the stored 
+    /// region on the full path-or-thread if a subregion is stored.
+    ///
+    /// If no end position is stored, NO_END_POSITION may be returned for the
+    /// end position.
+    virtual std::pair<int64_t, int64_t> get_subrange(const path_handle_t& handle) const;
+    static const std::pair<int64_t, int64_t> NO_SUBRANGE;
+    static const int64_t NO_END_POSITION;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Stock interface that uses backing virtual methods
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Loop through all the paths with the given sense. Returns false and
+    /// stops if the iteratee returns false.
+    template<typename Iteratee>
+    bool for_each_path_of_sense(const Sense& sense, const Iteratee& iteratee) const;
+    
+    /// Loop through all steps on the given handle for paths with the given
+    /// sense. Returns false and stops if the iteratee returns false.
+    /// TODO: Take the opportunity to make steps track orientation better?
+    template<typename Iteratee>
+    bool for_each_step_of_sense(const handle_t& visited, const Sense& sense, const Iteratee& iteratee) const;
+    
+protected:
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Backing protected virtual methods that have a default implementation
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Loop through all the paths with the given sense. Returns false and
+    /// stops if the iteratee returns false.
+    virtual bool for_each_path_of_sense_impl(const Sense& sense, const std::function<bool(const path_handle_t&)>& iteratee) const;
+    
+    /// Loop through all steps on the given handle for paths with the given
+    /// sense. Returns false and stops if the iteratee returns false.
+    virtual bool for_each_step_of_sense_impl(const handle_t& visited, const Sense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const;
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Backing methods that need to be implemented for default implementation
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Look up the name of a path from a handle to it
+    virtual std::string get_path_name(const path_handle_t& path_handle) const = 0;
+    
+private:
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Internal machinery for path name mini-format
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Separator used to separate path name components
+    static const char SEPARATOR;
+    // Ranges are set off with some additional characters.
+    static const char RANGE_START_SEPARATOR;
+    static const char RANGE_END_SEPARATOR;
+    static const char RANGE_TERMINATOR;
+    
+    // And we use these for parsing
+    static const std::regex FORMAT;
+    static const size_t ASSEMBLY_OR_NAME_MATCH;
+    static const size_t LOCUS_MATCH_WITHOUT_HAPLOTYPE;
+    static const size_t HAPLOTYPE_MATCH;
+    static const size_t LOCUS_MATCH_WITH_HAPLOTYPE;
+    static const size_t PHASE_BLOCK_MATCH;
+    static const size_t RANGE_START_MATCH;
+    static const size_t RANGE_END_MATCH;
+};
+
+////////////////////////////////////////////////////////////////////////////
+// Template Implementations
+////////////////////////////////////////////////////////////////////////////
+
+template<typename Iteratee>
+bool PathMetadata::for_each_path_of_sense(const Sense& sense, const Iteratee& iteratee) const {
+    return for_each_path_of_sense_impl(sense, BoolReturningWrapper<Iteratee>::wrap(iteratee));
+}
+
+template<typename Iteratee>
+bool PathMetadata::for_each_step_of_sense(const handle_t& visited, const Sense& sense, const Iteratee& iteratee) const {
+    return for_each_step_of_sense_impl(visited, sense, BoolReturningWrapper<Iteratee>::wrap(iteratee));
+}
+
+}
+#endif

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -104,6 +104,46 @@ public:
     static const int64_t NO_END_POSITION;
     
     ////////////////////////////////////////////////////////////////////////////
+    // Tools for converting back and forth with single-string path names
+    ////////////////////////////////////////////////////////////////////////////
+    
+    /// Extract the sense of a path from the given formatted path name, if
+    /// possible. If not possible, return SENSE_GENERIC.
+    static Sense parse_sense(const std::string& path_name);
+    
+    /// Get the name of the sample or assembly embedded in the given formatted
+    /// path name, or NO_SAMPLE_NAME if it does not belong to one.
+    static std::string parse_sample_name(const std::string& path_name);
+    
+    /// Get the name of the contig or gene  embedded in the given formatted
+    /// path name, or NO_LOCUS_NAME if it does not belong to one.
+    static std::string parse_locus_name(const std::string& path_name);
+    
+    /// Get the haplotype number (0 or 1, for diploid) embedded in the given
+    /// formatted path name, or NO_HAPLOTYPE if it does not belong to one.
+    static int64_t parse_haplotype(const std::string& path_name);
+    
+    /// Get the phase block number (contiguously phased region of a sample,
+    /// contig, and haplotype) embedded in the given formatted path name, or
+    /// NO_PHASE_BLOCK if it does not belong to one.
+    static int64_t parse_phase_block(const std::string& path_name);
+    
+    /// Get the bounds embedded in the given formatted path name, or
+    /// NO_SUBRANGE if they are absent. If no end position is stored,
+    /// NO_END_POSITION may be returned for the end position.
+    static std::pair<int64_t, int64_t> parse_subrange(const std::string& path_name);
+    
+    /// Compose a formatted path name for the given metadata. Any item can be
+    /// the corresponding unset sentinel (PathMetadata::NO_LOCUS_NAME,
+    /// PathMetadata::NO_PHASE_BLOCK, etc.).
+    static std::string create_path_name(const PathMetadata::Sense& sense,
+                                        const std::string& sample,
+                                        const std::string& locus,
+                                        const int64_t& haplotype,
+                                        const int64_t& phase_block,
+                                        const std::pair<int64_t, int64_t>& subrange);
+    
+    ////////////////////////////////////////////////////////////////////////////
     // Stock interface that uses backing virtual methods
     ////////////////////////////////////////////////////////////////////////////
     
@@ -181,6 +221,13 @@ private:
     static const size_t PHASE_BLOCK_MATCH;
     static const size_t RANGE_START_MATCH;
     static const size_t RANGE_END_MATCH;
+    
+    /// Separator used to separate path name components
+    static const char SEPARATOR;
+    // Ranges are set off with some additional characters.
+    static const char RANGE_START_SEPARATOR;
+    static const char RANGE_END_SEPARATOR;
+    static const char RANGE_TERMINATOR;
 };
 
 ////////////////////////////////////////////////////////////////////////////

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -133,6 +133,15 @@ public:
     /// NO_END_POSITION may be returned for the end position.
     static std::pair<int64_t, int64_t> parse_subrange(const std::string& path_name);
     
+    /// Decompose a formatted path name into metadata.
+    static void parse_path_name(const std::string& path_name,
+                                PathMetadata::Sense& sense,
+                                std::string& sample,
+                                std::string& locus,
+                                int64_t& haplotype,
+                                int64_t& phase_block,
+                                std::pair<int64_t, int64_t>& subrange);
+
     /// Compose a formatted path name for the given metadata. Any item can be
     /// the corresponding unset sentinel (PathMetadata::NO_LOCUS_NAME,
     /// PathMetadata::NO_PHASE_BLOCK, etc.).

--- a/src/mutable_path_metadata.cpp
+++ b/src/mutable_path_metadata.cpp
@@ -8,12 +8,6 @@
 
 namespace handlegraph {
 
-// And these are the constants for parsing path names out into metadata
-const char MutablePathMetadata::SEPARATOR = '#';
-const char MutablePathMetadata::RANGE_START_SEPARATOR = '[';
-const char MutablePathMetadata::RANGE_END_SEPARATOR = '-';
-const char MutablePathMetadata::RANGE_TERMINATOR = ']';
-
 path_handle_t MutablePathMetadata::create_path(const PathMetadata::Sense& sense,
                                                const std::string& sample,
                                                const std::string& locus,
@@ -21,59 +15,8 @@ path_handle_t MutablePathMetadata::create_path(const PathMetadata::Sense& sense,
                                                const int64_t& phase_block,
                                                const std::pair<int64_t, int64_t>& subrange,
                                                bool is_circular) {
-                                               
     
-    std::stringstream name_builder;
-    
-    if (sample != NO_SAMPLE_NAME) {
-        if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path cannot be created with a sample");
-        }
-        name_builder << sample << SEPARATOR;
-    }
-    if (locus != NO_LOCUS_NAME) {
-        name_builder << locus;
-    } else {
-        if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path cannot be created without a locus/name");
-        } else if (sense == SENSE_REFERENCE) {
-            throw std::runtime_error("Referecne path cannot be created without a locus");
-        } else if (sense == SENSE_HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path cannot be created without a locus");
-        }
-    }
-    if (haplotype != NO_HAPLOTYPE) {
-        if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path cannot be created with a haplotype number");
-        }
-        name_builder << SEPARATOR << haplotype;
-    } else {
-        if (sense == SENSE_HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path cannot be created without a haplotype number");
-        }
-    }
-    if (phase_block != NO_PHASE_BLOCK) {
-        if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path cannot be created with a phase block");
-        } else if (sense == SENSE_REFERENCE) {
-            throw std::runtime_error("Reference path cannot be created with a phase block");
-        }
-        name_builder << SEPARATOR << phase_block;
-    } else {
-        if (sense == SENSE_HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path cannot be created without a phase block");
-        }
-    }
-    if (subrange != NO_SUBRANGE) {
-        // Everything can have a subrange.
-        name_builder << RANGE_START_SEPARATOR << subrange.first;
-        if (subrange.second != NO_END_POSITION) {
-            name_builder << RANGE_END_SEPARATOR << subrange.second;
-        }
-        name_builder << RANGE_TERMINATOR;
-    }
-    
-    return create_path_handle(name_builder.str(), is_circular);
+    return create_path_handle(PathMetadata::create_path_name(sense, sample, locus, haplotype, phase_block, subrange), is_circular);
 }
 
 }

--- a/src/mutable_path_metadata.cpp
+++ b/src/mutable_path_metadata.cpp
@@ -4,19 +4,76 @@
 
 #include "handlegraph/mutable_path_metadata.hpp"
 
+#include <sstream>
+
 namespace handlegraph {
 
-path_handle_t create_path(const PathMetadata::Sense& sense,
-                          const std::string& sample,
-                          const std::string& locus,
-                          const int64_t& haplotype,
-                          const int64_t& phase_block,
-                          const std::pair<int64_t, int64_t>& subrange,
-                          bool is_circular) {
+// And these are the constants for parsing path names out into metadata
+const char MutablePathMetadata::SEPARATOR = '#';
+const char MutablePathMetadata::RANGE_START_SEPARATOR = '[';
+const char MutablePathMetadata::RANGE_END_SEPARATOR = '-';
+const char MutablePathMetadata::RANGE_TERMINATOR = ']';
 
-    // TODO: implement
-    throw std::runtime_error("Unimplemented!");
-
+path_handle_t MutablePathMetadata::create_path(const PathMetadata::Sense& sense,
+                                               const std::string& sample,
+                                               const std::string& locus,
+                                               const int64_t& haplotype,
+                                               const int64_t& phase_block,
+                                               const std::pair<int64_t, int64_t>& subrange,
+                                               bool is_circular) {
+                                               
+    
+    std::stringstream name_builder;
+    
+    if (sample != NO_SAMPLE_NAME) {
+        if (sense == SENSE_GENERIC) {
+            throw std::runtime_error("Generic path cannot be created with a sample");
+        }
+        name_builder << sample << SEPARATOR;
+    }
+    if (locus != NO_LOCUS_NAME) {
+        name_builder << locus;
+    } else {
+        if (sense == SENSE_GENERIC) {
+            throw std::runtime_error("Generic path cannot be created without a locus/name");
+        } else if (sense == SENSE_REFERENCE) {
+            throw std::runtime_error("Referecne path cannot be created without a locus");
+        } else if (sense == SENSE_HAPLOTYPE) {
+            throw std::runtime_error("Haplotype path cannot be created without a locus");
+        }
+    }
+    if (haplotype != NO_HAPLOTYPE) {
+        if (sense == SENSE_GENERIC) {
+            throw std::runtime_error("Generic path cannot be created with a haplotype number");
+        }
+        name_builder << SEPARATOR << haplotype;
+    } else {
+        if (sense == SENSE_HAPLOTYPE) {
+            throw std::runtime_error("Haplotype path cannot be created without a haplotype number");
+        }
+    }
+    if (phase_block != NO_PHASE_BLOCK) {
+        if (sense == SENSE_GENERIC) {
+            throw std::runtime_error("Generic path cannot be created with a phase block");
+        } else if (sense == SENSE_REFERENCE) {
+            throw std::runtime_error("Reference path cannot be created with a phase block");
+        }
+        name_builder << SEPARATOR << phase_block;
+    } else {
+        if (sense == SENSE_HAPLOTYPE) {
+            throw std::runtime_error("Haplotype path cannot be created without a phase block");
+        }
+    }
+    if (subrange != NO_SUBRANGE) {
+        // Everything can have a subrange.
+        name_builder << RANGE_START_SEPARATOR << subrange.first;
+        if (subrange.second != NO_END_POSITION) {
+            name_builder << RANGE_END_SEPARATOR << subrange.second;
+        }
+        name_builder << RANGE_TERMINATOR;
+    }
+    
+    return create_path_handle(name_builder.str(), is_circular);
 }
 
 }

--- a/src/mutable_path_metadata.cpp
+++ b/src/mutable_path_metadata.cpp
@@ -1,0 +1,22 @@
+/** \file mutable_path_metadata.cpp
+ * Implement MutablePathMetadata interface's default implementation.
+ */
+
+#include "handlegraph/mutable_path_metadata.hpp"
+
+namespace handlegraph {
+
+path_handle_t create_path(const PathMetadata::Sense& sense,
+                          const std::string& sample,
+                          const std::string& locus,
+                          const int64_t& haplotype,
+                          const int64_t& phase_block,
+                          const std::pair<int64_t, int64_t>& subrange,
+                          bool is_circular) {
+
+    // TODO: implement
+    throw std::runtime_error("Unimplemented!");
+
+}
+
+}

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -315,10 +315,21 @@ std::string PathMetadata::create_path_name(const PathMetadata::Sense& sense,
     return name_builder.str();
 }
 
-bool PathMetadata::for_each_path_of_sense_impl(const Sense& sense, const std::function<bool(const path_handle_t&)>& iteratee) const {
+bool PathMetadata::for_each_path_matching_impl(const std::unordered_set<PathMetadata::Sense>* senses,
+                                               const std::unordered_set<std::string>* samples,
+                                               const std::unordered_set<std::string>* loci,
+                                               const std::function<bool(const path_handle_t&)>& iteratee) const {
     return for_each_path_handle_impl([&](const path_handle_t& handle) {
-        if (get_sense(handle) != sense) {
-            // Skip this non-matching handle
+        if (senses && !senses->count(get_sense(handle))) {
+            // Wrong sense
+            return true;
+        }
+        if (samples && !samples->count(get_sample_name(handle))) {
+            // Wrong sample
+            return true;
+        }
+        if (loci && !loci->count(get_locus_name(handle))) {
+            // Wrong sample
             return true;
         }
         // And emit any matching handles

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -78,9 +78,12 @@ PathMetadata::Sense PathMetadata::parse_sense(const std::string& path_name) {
         if (result[PHASE_BLOCK_MATCH].matched) {
             // It's a haplotype because it has a phase block
             return SENSE_HAPLOTYPE;
-        } else {
-            // It's a reference
+        } else if (result[LOCUS_MATCH_WITHOUT_HAPLOTYPE].matched || result[LOCUS_MATCH_WITH_HAPLOTYPE].matched) {
+            // It's a reference because it has a locus and a sample
             return SENSE_REFERENCE;
+        } else {
+            // It's just a one-piece generic name
+            return SENSE_GENERIC;
         }
     } else {
         // We can't parse this at all.
@@ -201,9 +204,14 @@ void PathMetadata::parse_path_name(const std::string& path_name,
     // regex? With yet a third set of functions?
     if (matched) {
         if (result[PHASE_BLOCK_MATCH].matched) {
+            // It's a haplotype because it has a phase block.
             sense = SENSE_HAPLOTYPE;
-        } else {
+        } if (result[LOCUS_MATCH_WITHOUT_HAPLOTYPE].matched || result[LOCUS_MATCH_WITH_HAPLOTYPE].matched) {
+            // It's a reference because it has a locus and a sample
             sense = SENSE_REFERENCE;
+        } else {
+            // It's just a one-piece generic name
+            sense = SENSE_GENERIC;
         }
         
         if (result[LOCUS_MATCH_WITH_HAPLOTYPE].matched) {

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -14,12 +14,6 @@ const int64_t PathMetadata::NO_PHASE_BLOCK = -1;
 const int64_t PathMetadata::NO_END_POSITION = -1;
 const std::pair<int64_t, int64_t> PathMetadata::NO_SUBRANGE{-1, PathMetadata::NO_END_POSITION};
 
-// And these are the constants for parsing path names out into metadata
-const char PathMetadata::SEPARATOR = '#';
-const char PathMetadata::RANGE_START_SEPARATOR = '[';
-const char PathMetadata::RANGE_END_SEPARATOR = '-';
-const char PathMetadata::RANGE_TERMINATOR = ']';
-
 // Format examples:
 // GRCh38#chrM (a reference)
 // CHM13#chr12 (another reference)
@@ -171,6 +165,28 @@ std::pair<int64_t, int64_t> PathMetadata::get_subrange(const path_handle_t& hand
     }
     
     return to_return;
+}
+
+bool PathMetadata::for_each_path_of_sense_impl(const Sense& sense, const std::function<bool(const path_handle_t&)>& iteratee) const {
+    return for_each_path_handle_impl([&](const path_handle_t& handle) {
+        if (get_sense(handle) != sense) {
+            // Skip this non-matching handle
+            return true;
+        }
+        // And emit any matching handles
+        return iteratee(handle);
+    });
+}
+    
+bool PathMetadata::for_each_step_of_sense_impl(const handle_t& visited, const Sense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const {
+    return for_each_step_on_handle_impl(visited, [&](const step_handle_t& handle) {
+        if (get_sense(get_path_handle_of_step(handle)) != sense) {
+            // Skip this non-matching path's step
+            return true;
+        }
+        // And emit any steps on matching paths
+        return iteratee(handle);
+    });
 }
 
 }

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -1,0 +1,177 @@
+/** \file path_metadata.cpp
+ * Implement PathMetadata interface's default implementation.
+ */
+
+#include "handlegraph/path_metadata.hpp"
+
+namespace handlegraph {
+
+// These are all our no-value placeholders.
+const std::string PathMetadata::NO_SAMPLE_NAME = "";
+const std::string PathMetadata::NO_LOCUS_NAME = "";
+const int64_t PathMetadata::NO_HAPLOTYPE = -1;
+const int64_t PathMetadata::NO_PHASE_BLOCK = -1;
+const int64_t PathMetadata::NO_END_POSITION = -1;
+const std::pair<int64_t, int64_t> PathMetadata::NO_SUBRANGE{-1, PathMetadata::NO_END_POSITION};
+
+// And these are the constants for parsing path names out into metadata
+const char PathMetadata::SEPARATOR = '#';
+const char PathMetadata::RANGE_START_SEPARATOR = '[';
+const char PathMetadata::RANGE_END_SEPARATOR = '-';
+const char PathMetadata::RANGE_TERMINATOR = ']';
+
+// Format examples:
+// GRCh38#chrM (a reference)
+// CHM13#chr12 (another reference)
+// CHM13#chr12[300-400] (part of a reference)
+// NA19239#1#chr1 (a diploid reference)
+// NA29239#1#chr1#0 (a haplotype)
+// 1[100] (part of a generic path)
+// We don't support extraneous [] in name components in the structured format, or in names with ranges.
+// TODO: escape them?
+
+// So we match a regax for:
+// One separator-free name component
+// Up to 3 other optional separator-free name components, led by separators tacked on by non-capturing groups. Last one must be a number.
+// Possibly a bracket-bounded non-capturing group at the end
+// Which has a number, and possibly a dash-led non-capturing group with a number.
+// Match number:                         1           2             3             4           5        6
+const std::regex PathMetadata::FORMAT(R"(([^[#]*)(?:#([^[#]*))?(?:#([^[#]*))?(?:#(\d+))?(?:\[(\d+)(?:-(\d+))\])?)");
+const size_t PathMetadata::ASSEMBLY_OR_NAME_MATCH = 1;
+const size_t PathMetadata::LOCUS_MATCH_WITHOUT_HAPLOTYPE = 2;
+const size_t PathMetadata::HAPLOTYPE_MATCH = 2;
+const size_t PathMetadata::LOCUS_MATCH_WITH_HAPLOTYPE = 3;
+const size_t PathMetadata::PHASE_BLOCK_MATCH = 4;
+const size_t PathMetadata::RANGE_START_MATCH = 5;
+const size_t PathMetadata::RANGE_END_MATCH = 6;
+
+
+PathMetadata::Sense PathMetadata::get_sense(const path_handle_t& handle) const {
+    // Get the name.
+    std::string path_name = get_path_name(handle);
+    // Match the regex
+    std::smatch result;
+    if (std::regex_match(path_name, result, FORMAT)) {
+        // It's something we know.
+        if (result[PHASE_BLOCK_MATCH].matched) {
+            // It's a haplotype because it has a phase block
+            return SENSE_HAPLOTYPE;
+        } else {
+            // It's a reference
+            return SENSE_REFERENCE;
+        }
+    } else {
+        // We can't parse this at all.
+        return SENSE_GENERIC;
+    }
+}
+
+
+
+std::string PathMetadata::get_sample_name(const path_handle_t& handle) const {
+    // Get the name.
+    std::string path_name = get_path_name(handle);
+    // Match the regex
+    std::smatch result;
+    if (std::regex_match(path_name, result, FORMAT)) {
+        if (result[LOCUS_MATCH_WITH_HAPLOTYPE].matched || result[LOCUS_MATCH_WITHOUT_HAPLOTYPE].matched) {
+            // There's a locus later, so the first thing doesn't have to be locus, so it can be sample.
+            return result[ASSEMBLY_OR_NAME_MATCH].str();
+        } else {
+            // There's nothing but the locus and maybe a range.
+            return NO_SAMPLE_NAME;
+        }
+    } else {
+        // No sample name.
+        return NO_SAMPLE_NAME;
+    }
+}
+
+
+std::string PathMetadata::get_locus_name(const path_handle_t& handle) const {
+    // Get the name.
+    std::string path_name = get_path_name(handle);
+    // Match the regex
+    std::smatch result;
+    if (std::regex_match(path_name, result, FORMAT)) {
+        if (result[LOCUS_MATCH_WITH_HAPLOTYPE].matched) {
+            // There's a phase and a locus
+            return result[LOCUS_MATCH_WITH_HAPLOTYPE].str();
+        } else if (result[LOCUS_MATCH_WITHOUT_HAPLOTYPE].matched) {
+            // There's a locus but no phase
+            return result[LOCUS_MATCH_WITHOUT_HAPLOTYPE].str();
+        } else {
+            // There's nothing but the locus and maybe a range.
+            return result[ASSEMBLY_OR_NAME_MATCH].str();
+        }
+    } else {
+        // Just the whole thing should come out here.
+        return path_name;
+    }
+}
+
+
+int64_t PathMetadata::get_haplotype(const path_handle_t& handle) const {
+    // Get the name.
+    std::string path_name = get_path_name(handle);
+    // Match the regex
+    std::smatch result;
+    if (std::regex_match(path_name, result, FORMAT)) {
+        if (result[LOCUS_MATCH_WITH_HAPLOTYPE].matched) {
+            // There's a haplotype.
+            // We just assume it's actually a number.
+            return std::stoll(result[HAPLOTYPE_MATCH].str());
+        } else {
+            // No haplotype is stored
+            return NO_HAPLOTYPE;
+        }
+    } else {
+        // We can't parse this at all.
+        return NO_HAPLOTYPE;
+    }
+}
+
+
+int64_t PathMetadata::get_phase_block(const path_handle_t& handle) const {
+    // Get the name.
+    std::string path_name = get_path_name(handle);
+    // Match the regex
+    std::smatch result;
+    if (std::regex_match(path_name, result, FORMAT)) {
+        if (result[PHASE_BLOCK_MATCH].matched) {
+            // There's a phase block.
+            // We just assume it's actually a number.
+            return std::stoll(result[PHASE_BLOCK_MATCH].str());
+        } else {
+            // No phase block is stored
+            return NO_PHASE_BLOCK;
+        }
+    } else {
+        // We can't parse this at all.
+        return NO_PHASE_BLOCK;
+    }
+}
+
+std::pair<int64_t, int64_t> PathMetadata::get_subrange(const path_handle_t& handle) const {
+    auto to_return = NO_SUBRANGE;
+    
+    // Get the name.
+    std::string path_name = get_path_name(handle);
+    // Match the regex
+    std::smatch result;
+    if (std::regex_match(path_name, result, FORMAT)) {
+        if (result[RANGE_START_MATCH].matched) {
+            // There is a range start, so pasre it
+            to_return.first = std::stoll(result[RANGE_START_MATCH].str());
+            if (result[RANGE_END_MATCH].matched) {
+                // There is also an end, so parse that too
+                to_return.second = std::stoll(result[RANGE_END_MATCH].str());
+            }
+        }
+    }
+    
+    return to_return;
+}
+
+}
+

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -280,7 +280,7 @@ std::string PathMetadata::create_path_name(const PathMetadata::Sense& sense,
         if (sense == SENSE_GENERIC) {
             throw std::runtime_error("Generic path cannot have a haplotype number");
         }
-        name_builder << SEPARATOR << haplotype;
+        name_builder << haplotype << SEPARATOR;
     } else {
         if (sense == SENSE_HAPLOTYPE) {
             throw std::runtime_error("Haplotype path must have a haplotype number");

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -266,24 +266,19 @@ std::string PathMetadata::create_path_name(const PathMetadata::Sense& sense,
     
     if (sample != NO_SAMPLE_NAME) {
         if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path must have a sample");
+            throw std::runtime_error("Generic path cannot have a sample");
         }
         name_builder << sample << SEPARATOR;
-    }
-    if (locus != NO_LOCUS_NAME) {
-        name_builder << locus;
     } else {
-        if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path must have a locus/name");
-        } else if (sense == SENSE_REFERENCE) {
-            throw std::runtime_error("Referecne path must have a locus");
+        if (sense == SENSE_REFERENCE) {
+            throw std::runtime_error("Reference path must have a sample name");
         } else if (sense == SENSE_HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path must have a locus");
+            throw std::runtime_error("Haplotype path must have a sample name");
         }
     }
     if (haplotype != NO_HAPLOTYPE) {
         if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path must have a haplotype number");
+            throw std::runtime_error("Generic path cannot have a haplotype number");
         }
         name_builder << SEPARATOR << haplotype;
     } else {
@@ -291,11 +286,22 @@ std::string PathMetadata::create_path_name(const PathMetadata::Sense& sense,
             throw std::runtime_error("Haplotype path must have a haplotype number");
         }
     }
+    if (locus != NO_LOCUS_NAME) {
+        name_builder << locus;
+    } else {
+        if (sense == SENSE_GENERIC) {
+            throw std::runtime_error("Generic path must have a locus/name");
+        } else if (sense == SENSE_REFERENCE) {
+            throw std::runtime_error("Reference path must have a locus");
+        } else if (sense == SENSE_HAPLOTYPE) {
+            throw std::runtime_error("Haplotype path must have a locus");
+        }
+    }
     if (phase_block != NO_PHASE_BLOCK) {
         if (sense == SENSE_GENERIC) {
-            throw std::runtime_error("Generic path must have a phase block");
+            throw std::runtime_error("Generic path cannot have a phase block");
         } else if (sense == SENSE_REFERENCE) {
-            throw std::runtime_error("Reference path must have a phase block");
+            throw std::runtime_error("Reference path cannot have a phase block");
         }
         name_builder << SEPARATOR << phase_block;
     } else {


### PR DESCRIPTION
This will fix #75 by adding a metadata API to let you get e.g. the sample and haplotype of a path, and some methods that are specified to let you obtain path handles for haplotypes.

I had to complicate the search methods a bit from what I proposed in #75, because almost immediately upon trying to use this I started needing to e.g. look up all the haplotypes for a sample, which wasn't supported in the original formulation. 