### PR TITLE
Add more modes to Dijkstra search

### DIFF
--- a/src/dijkstra.cpp
+++ b/src/dijkstra.cpp
@@ -13,6 +13,8 @@ namespace algorithms {
 
 using namespace std;
 
+//#define debug_vg_algorithms
+
 bool dijkstra(const HandleGraph* g, handle_t start,
               function<bool(const handle_t&, size_t)> reached_callback,
               bool traverse_leftward, bool prune, bool cycle_to_start) {
@@ -21,13 +23,20 @@ bool dijkstra(const HandleGraph* g, handle_t start,
     starts.insert(start);          
     
     // Implement single-start search in terms of multi-start search
-    return dijkstra(g, starts, reached_callback, traverse_leftward, prune);
+    return dijkstra(g, starts, reached_callback, traverse_leftward, prune, cycle_to_start);
               
 }
 
 bool dijkstra(const HandleGraph* g, const unordered_set<handle_t>& starts,
               function<bool(const handle_t&, size_t)> reached_callback,
               bool traverse_leftward, bool prune, bool cycle_to_start) {
+
+#ifdef debug_vg_algorithms
+    cerr << "Doing Dijkstra traversal from " << starts.size() << " start points, "
+        << (traverse_leftward ? "left" : "right")
+        << ", with pruning " << (prune ? "on" : "off")
+        << " and cycle visits to starts " << (cycle_to_start ? "on" : "off") << endl;
+#endif
 
     // We keep a priority queue so we can visit the handle with the shortest
     // distance next. We put handles in here whenever we see them with shorter

--- a/src/include/handlegraph/algorithms/dijkstra.hpp
+++ b/src/include/handlegraph/algorithms/dijkstra.hpp
@@ -27,17 +27,21 @@ namespace algorithms {
 /// reached_callback function must return true to continue the search, and
 /// false to abort it early.
 ///
+/// If prune is true, aborts the search by pruining out edges away from the
+/// current node and continuing with the next node in the queue. If it is
+/// false, the whole search stops as soon as the callback returns false.
+///
 /// Returns true if the search terminated normally, and false if it was
 /// aborted.
 bool dijkstra(const HandleGraph* g, handle_t start,
               std::function<bool(const handle_t&, size_t)> reached_callback,
-              bool traverse_leftward = false);
+              bool traverse_leftward = false, bool prune = false);
 
 /// Same as the single-start version, except allows starting from multiple
 /// handles, all at distance 0.
 bool dijkstra(const HandleGraph* g, const std::unordered_set<handle_t>& starts,
               std::function<bool(const handle_t&, size_t)> reached_callback,
-              bool traverse_leftward = false);
+              bool traverse_leftward = false, bool prune = false);
                                                       
 }
 }

--- a/src/include/handlegraph/algorithms/dijkstra.hpp
+++ b/src/include/handlegraph/algorithms/dijkstra.hpp
@@ -31,17 +31,20 @@ namespace algorithms {
 /// current node and continuing with the next node in the queue. If it is
 /// false, the whole search stops as soon as the callback returns false.
 ///
+/// If cycle_to_start is true, doesn't visit the start node initially, so it
+/// can be visited by a cycle that comes back to it, if any.
+///
 /// Returns true if the search terminated normally, and false if it was
 /// aborted.
 bool dijkstra(const HandleGraph* g, handle_t start,
               std::function<bool(const handle_t&, size_t)> reached_callback,
-              bool traverse_leftward = false, bool prune = false);
+              bool traverse_leftward = false, bool prune = false, bool cycle_to_start = false);
 
 /// Same as the single-start version, except allows starting from multiple
 /// handles, all at distance 0.
 bool dijkstra(const HandleGraph* g, const std::unordered_set<handle_t>& starts,
               std::function<bool(const handle_t&, size_t)> reached_callback,
-              bool traverse_leftward = false, bool prune = false);
+              bool traverse_leftward = false, bool prune = false, bool cycle_to_start = false);
                                                       
 }
 }


### PR DESCRIPTION
This lets you use `vg::algorithms::dijkstra()` to do a pruned search: instead of stopping when you return false for a node, it will instead just stop exploring from that node, and keep exploring from other nodes.

It also lets you skip the initial visit(s) to the starting node(s), so they can be visited later with shortest paths to them from themselves or other start nodes.