### PR TITLE
enable GCC v13.1 compilation

### DIFF
--- a/src/include/handlegraph/serializable.hpp
+++ b/src/include/handlegraph/serializable.hpp
@@ -1,6 +1,8 @@
 #ifndef HANDLEGRAPH_SERIALIZABLE_HPP_INCLUDED
 #define HANDLEGRAPH_SERIALIZABLE_HPP_INCLUDED
 
+#include <cstdint>
+
 /** \file 
  * Defines an interface for objects that are saveable and loadable. 
  */


### PR DESCRIPTION
This one-liner enables us to compile libhandlegraph with GCC 13.1. This update is required so we can actually compile ODGI with this compiler version. See https://github.com/pangenome/odgi/pull/507.