### PR TITLE
Handle full parsing of two-part path names

### DIFF
--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -222,9 +222,14 @@ void PathMetadata::parse_path_name(const std::string& path_name,
             locus = result[LOCUS_MATCH_ANY].str();
             haplotype = std::stoll(result[HAPLOTYPE_MATCH].str());
         } else if (result[LOCUS_MATCH_NUMERICAL_WITHOUT_HAPLOTYPE].matched) {
-            // There's a locus but no haplotype, and a sample
+            // There's a numerical locus but no haplotype, and a sample
             sample = result[ASSEMBLY_OR_NAME_MATCH].str();
             locus = result[LOCUS_MATCH_NUMERICAL_WITHOUT_HAPLOTYPE].str();
+            haplotype = NO_HAPLOTYPE;
+        } else if (result[LOCUS_MATCH_ANY].matched) {
+            // There's a non-numerical locus but no haplotype, and a sample
+            sample = result[ASSEMBLY_OR_NAME_MATCH].str();
+            locus = result[LOCUS_MATCH_ANY].str();
             haplotype = NO_HAPLOTYPE;
         } else {
             // There's nothing but the locus and maybe a range.


### PR DESCRIPTION
I missed a case in #91 and the full and by-field parsers got out of sync. The full one lost the ability to handle e.g. `GRCh38#chr1`, which is pretty important but wasn't in the vg tests.

This should fix the bug, and I am adding some tests to vg.