### PR TITLE
Add a batch path destroy function with a default implementation

### DIFF
--- a/src/include/handlegraph/mutable_path_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_handle_graph.hpp
@@ -26,6 +26,11 @@ public:
      * Destroy the given path. Invalidates handles to the path and its steps.
      */
     virtual void destroy_path(const path_handle_t& path_handle) = 0;
+    
+    /**
+     * Destroy the given set of paths. Invalidates handles to all the paths and their steps.
+     */
+    virtual void destroy_paths(const std::vector<path_handle_t>& paths);
 
     /**
      * Create a path with the given name. The caller must ensure that no path

--- a/src/mutable_path_handle_graph.cpp
+++ b/src/mutable_path_handle_graph.cpp
@@ -6,6 +6,12 @@
 
 namespace handlegraph {
 
+void MutablePathHandleGraph::destroy_paths(const std::vector<path_handle_t>& paths) {
+    for (const auto& path : paths) {
+        destroy_path(path);
+    }
+}
+
 void MutablePathHandleGraph::pop_front_step(const path_handle_t& path_handle) {
     step_handle_t begin = path_begin(path_handle);
     step_handle_t next = get_next_step(begin);


### PR DESCRIPTION
Pretty straightforward. I'm adding this to facilitate a more efficient batch path destroy in `libbdsg`.