### PR TITLE
Add an interface in DeletableHandleGraph to change the sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set (CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 add_library(handlegraph_objs OBJECT
   src/deletable_handle_graph.cpp
+  src/mutable_path_deletable_handle_graph.cpp
   src/dfs.cpp
   src/handle_graph.cpp
   src/mutable_handle_graph.cpp

--- a/src/deletable_handle_graph.cpp
+++ b/src/deletable_handle_graph.cpp
@@ -21,6 +21,9 @@ handle_t DeletableHandleGraph::truncate_handle(const handle_t& handle, bool trun
 handle_t DeletableHandleGraph::change_sequence(const handle_t& handle, const std::string& sequence) {
     // new handle with the new sequence
     handle_t new_handle = create_handle(sequence);
+    if (get_is_reverse(handle)) {
+        new_handle = flip(new_handle);
+    }
     
     // copy its edges
     follow_edges(handle, false, [&](const handle_t& next) {

--- a/src/deletable_handle_graph.cpp
+++ b/src/deletable_handle_graph.cpp
@@ -18,6 +18,27 @@ handle_t DeletableHandleGraph::truncate_handle(const handle_t& handle, bool trun
     }
 }
 
+handle_t DeletableHandleGraph::change_sequence(const handle_t& handle, const std::string& sequence) {
+    // new handle with the new sequence
+    handle_t new_handle = create_handle(sequence);
+    
+    // copy its edges
+    follow_edges(handle, false, [&](const handle_t& next) {
+        create_edge(new_handle, next);
+    });
+    follow_edges(handle, true, [&](const handle_t& prev) {
+        // ensure that we don't double add a non-reversing self-edge
+        if (get_id(prev) != get_id(handle) || get_is_reverse(prev)) {
+            create_edge(prev, new_handle);
+        }
+    });
+    
+    // clear the original
+    destroy_handle(handle);
+    
+    return new_handle;
+}
+
 }
 
 

--- a/src/include/handlegraph/deletable_handle_graph.hpp
+++ b/src/include/handlegraph/deletable_handle_graph.hpp
@@ -30,6 +30,11 @@ public:
     /// May **NOT** be called during iteration along a path, if it could destroy that path.
     virtual void destroy_handle(const handle_t& handle) = 0;
     
+    /// Change the sequence of handle's forward orientation to a new sequence. Returns a (possibly
+    /// handle to the node with the new sequence. May invalidate the existing handle. Updates
+    /// alterered) paths if called through a class inheriting a MutablePathHandleGraph interface.
+    virtual handle_t change_sequence(const handle_t& handle, const std::string& sequence);
+    
     /// Remove the edge connecting the given handles in the given order and orientations.
     /// Ignores nonexistent edges.
     /// Does not update any stored paths.

--- a/src/include/handlegraph/deletable_handle_graph.hpp
+++ b/src/include/handlegraph/deletable_handle_graph.hpp
@@ -30,9 +30,10 @@ public:
     /// May **NOT** be called during iteration along a path, if it could destroy that path.
     virtual void destroy_handle(const handle_t& handle) = 0;
     
-    /// Change the sequence of handle's forward orientation to a new sequence. Returns a (possibly
-    /// handle to the node with the new sequence. May invalidate the existing handle. Updates
-    /// alterered) paths if called through a class inheriting a MutablePathHandleGraph interface.
+    /// Change the sequence of handle's forward orientation to a new sequence. Returns a (possibly altered)
+    /// handle to the node with the new sequence. The returned handle has the same orientation as the
+    /// handle provided as an argument. May invalidate existing handles to the node. Updates paths to
+    /// follow the new node if called through a class inheriting a MutablePathHandleGraph interface.
     virtual handle_t change_sequence(const handle_t& handle, const std::string& sequence);
     
     /// Remove the edge connecting the given handles in the given order and orientations.

--- a/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
@@ -21,6 +21,11 @@ public:
     
     // No extra methods. Deleting a node or edge that is contained in a path is undefined behavior.
     // The method clear() is now assumed to delete paths as well as nodes and edges.
+    // The method change_sequence() is now assumed to update paths if the underlying handle changes as a result.
+    
+    // the default implementation is augmented to meet the new semantics
+    virtual handle_t change_sequence(const handle_t& handle, const std::string& sequence);
+
 };
 
 }

--- a/src/mutable_path_deletable_handle_graph.cpp
+++ b/src/mutable_path_deletable_handle_graph.cpp
@@ -14,10 +14,10 @@ handle_t MutablePathDeletableHandleGraph::change_sequence(const handle_t& handle
     // new handle with the new sequence
     handle_t new_handle = create_handle(sequence);
     // copy its edges
-    follow_edges(handle, false, [&](const handle_t& next) {
+    follow_edges(forward(handle), false, [&](const handle_t& next) {
         create_edge(new_handle, next);
     });
-    follow_edges(handle, true, [&](const handle_t& prev) {
+    follow_edges(forward(handle), true, [&](const handle_t& prev) {
         // ensure that we don't double add a non-reversing self-edge
         if (get_id(prev) != get_id(handle) || get_is_reverse(prev)) {
             create_edge(prev, new_handle);
@@ -31,10 +31,14 @@ handle_t MutablePathDeletableHandleGraph::change_sequence(const handle_t& handle
     });
     
     // replace them
-    std::vector<handle_t> rewriter(1, new_handle);
     for (const auto& step : steps) {
+        std::vector<handle_t> rewriter(1, get_is_reverse(get_handle_of_step(step)) ? flip(new_handle) : new_handle);
         rewrite_segment(step, get_next_step(step), rewriter);
     }
+    if (get_is_reverse(handle)) {
+        new_handle = flip(new_handle);
+    }
+    
     // clear the original
     destroy_handle(handle);
     

--- a/src/mutable_path_deletable_handle_graph.cpp
+++ b/src/mutable_path_deletable_handle_graph.cpp
@@ -1,0 +1,46 @@
+#include "handlegraph/mutable_path_deletable_handle_graph.hpp"
+
+/** \file mutable_path_deletable_handle_graph.cpp
+ * Implement methods for MutablePathDeletableHandleGraph.
+ */
+
+namespace handlegraph {
+
+handle_t MutablePathDeletableHandleGraph::change_sequence(const handle_t& handle,
+                                                          const std::string& sequence) {
+    // TODO: repetitive with DeletableHandleGraph, but we can't call it because it could destroy
+    // all the paths containing the handle as a side effect of the destroy_handle call at the end
+    
+    // new handle with the new sequence
+    handle_t new_handle = create_handle(sequence);
+    // copy its edges
+    follow_edges(handle, false, [&](const handle_t& next) {
+        create_edge(new_handle, next);
+    });
+    follow_edges(handle, true, [&](const handle_t& prev) {
+        // ensure that we don't double add a non-reversing self-edge
+        if (get_id(prev) != get_id(handle) || get_is_reverse(prev)) {
+            create_edge(prev, new_handle);
+        }
+    });
+    
+    // collect the steps we need to replace
+    std::vector<step_handle_t> steps;
+    for_each_step_on_handle(handle, [&](const step_handle_t& step) {
+        steps.push_back(step);
+    });
+    
+    // replace them
+    std::vector<handle_t> rewriter(1, new_handle);
+    for (const auto& step : steps) {
+        rewrite_segment(step, get_next_step(step), rewriter);
+    }
+    // clear the original
+    destroy_handle(handle);
+    
+    return new_handle;
+}
+
+}
+
+


### PR DESCRIPTION
This is part of a larger PR to allow sequences to be hard-masked in VG by internally replacing them with N's. 