### PR TITLE
Change PathMetadata::for_each_path_matching_impl to use for_each_path…

### DIFF
--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -340,22 +340,33 @@ bool PathMetadata::for_each_path_matching_impl(const std::unordered_set<PathSens
                                                const std::unordered_set<std::string>* samples,
                                                const std::unordered_set<std::string>* loci,
                                                const std::function<bool(const path_handle_t&)>& iteratee) const {
-    return for_each_path_handle_impl([&](const path_handle_t& handle) {
-        if (senses && !senses->count(get_sense(handle))) {
-            // Wrong sense
-            return true;
+
+    //If senses was not specified, do this for all senses
+    std::unordered_set<PathSense> all_senses = {PathSense::GENERIC, PathSense::REFERENCE, PathSense::HAPLOTYPE};
+    if (!senses) {
+        senses = &all_senses;
+    }
+
+    bool result = true;
+    for (const auto& sense : *senses) {
+        result &= for_each_path_of_sense(sense, [&](const path_handle_t& handle) {
+            if (samples && !samples->count(get_sample_name(handle))) {
+                // Wrong sample
+                return true;
+            }
+            if (loci && !loci->count(get_locus_name(handle))) {
+                // Wrong sample
+                return true;
+            }
+            // And emit any matching handles
+            return iteratee(handle);
+        });
+        if (!result) {
+            return result;
         }
-        if (samples && !samples->count(get_sample_name(handle))) {
-            // Wrong sample
-            return true;
-        }
-        if (loci && !loci->count(get_locus_name(handle))) {
-            // Wrong sample
-            return true;
-        }
-        // And emit any matching handles
-        return iteratee(handle);
-    });
+    }
+    return result;
+
 }
     
 bool PathMetadata::for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const {


### PR DESCRIPTION
…_of_sense instead of for_each_path_handle

I haven't been able to test this, but I think I'm running into a problem where I'm trying to call `for_each_path_matching()` from a `PathPositionHandleGraph` of a gbz to iterate through all paths in the graph, but instead of using `GBWTgraph::for_each_path_matching_impl`, it goes through `PathMetadata::for_each_path_matching_impl`, which uses `for_each_path_handle`, which can't see haplotype paths. 

This changes `PathMetadata::for_each_path_matching_impl` to use `for_each_path_of_sense` to go through all paths, including haplotype sense paths. 