### PR TITLE
No secret paths

### DIFF
--- a/src/copy_graph.cpp
+++ b/src/copy_graph.cpp
@@ -44,13 +44,10 @@ void copy_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandl
     //            throw runtime_error("error:[copy_handle_graph] cannot copy into a non-empty graph");
     //        }
     
-    // For every sense of path
-    for (auto& sense : {PathSense::REFERENCE, PathSense::GENERIC, PathSense::HAPLOTYPE}) {
-        // copy paths of that sense
-        from->for_each_path_of_sense(sense, [&](const path_handle_t& path_handle) {
-            copy_path(from, path_handle, into);
-        });
-    }
+    // copy paths of every sense of path
+    from->for_each_path_of_sense({PathSense::REFERENCE, PathSense::GENERIC, PathSense::HAPLOTYPE}, [&](const path_handle_t& path_handle) {
+        copy_path(from, path_handle, into);
+    });
 }
 
 void copy_path(const PathHandleGraph* from, const path_handle_t& from_path,

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -285,7 +285,13 @@ private:
 
 template<typename Iteratee>
 bool PathMetadata::for_each_path_of_sense(const PathSense& sense, const Iteratee& iteratee) const {
-    return for_each_path_of_sense({sense}, iteratee);
+    // TODO: If we try and call just on {sense} here, we *don't* successfully
+    // call the other overload but we also don't infinitely recurse at runtime;
+    // the iteratee just never sees anything. What's really going on???
+    //
+    // Anyway, we need to manually make a set to ensure we delegate to the other overload.
+    std::unordered_set<PathSense> senses{sense};
+    return for_each_path_of_sense(senses, iteratee);
 }
 
 template<typename Iteratee>

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -202,6 +202,11 @@ public:
     /// TODO: Take the opportunity to make steps track orientation better?
     template<typename Iteratee>
     bool for_each_step_of_sense(const handle_t& visited, const PathSense& sense, const Iteratee& iteratee) const;
+
+    /// Loop through all steps on the given handle for paths with any of the
+    /// given senses. Returns false and stops if the iteratee returns false.
+    template<typename Iteratee>
+    bool for_each_step_of_sense(const handle_t& visited, const std::unordered_set<PathSense>& senses, const Iteratee& iteratee) const;
     
 protected:
     
@@ -225,6 +230,10 @@ protected:
     /// Loop through all steps on the given handle for paths with the given
     /// sense. Returns false and stops if the iteratee returns false.
     virtual bool for_each_step_of_sense_impl(const handle_t& visited, const PathSense& sense, const std::function<bool(const step_handle_t&)>& iteratee) const;
+
+    /// Loop through all steps on the given handle for paths with any of the
+    /// given senses. Returns false and stops if the iteratee returns false.
+    virtual bool for_each_step_of_sense_impl(const handle_t& visited, const std::unordered_set<PathSense>& senses, const std::function<bool(const step_handle_t&)>& iteratee) const;
     
     ////////////////////////////////////////////////////////////////////////////
     // Backing methods that need to be implemented for default implementation
@@ -240,19 +249,11 @@ protected:
     
     /// Execute a function on each path in the graph. If it returns false, stop
     /// iteration. Returns true if we finished and false if we stopped early.
-    ///
-    /// If the graph contains compressed haplotype paths and properly
-    /// implements for_each_path_of_sense to retrieve them, they should not be
-    /// visible here. Only reference or generic named paths should be visible.
     virtual bool for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const = 0;
     
     /// Execute a function on each step of a handle in any path. If it
     /// returns false, stop iteration. Returns true if we finished and false if
     /// we stopped early.
-    ///
-    /// If the graph contains compressed haplotype paths and properly
-    /// implements for_each_step_of_sense to find them, they should not be
-    /// visible here. Only reference or generic named paths should be visible.
     virtual bool for_each_step_on_handle_impl(const handle_t& handle,
         const std::function<bool(const step_handle_t&)>& iteratee) const = 0;
     
@@ -332,6 +333,11 @@ bool PathMetadata::for_each_path_matching(const std::unordered_set<PathSense>& s
 template<typename Iteratee>
 bool PathMetadata::for_each_step_of_sense(const handle_t& visited, const PathSense& sense, const Iteratee& iteratee) const {
     return for_each_step_of_sense_impl(visited, sense, BoolReturningWrapper<Iteratee>::wrap(iteratee));
+}
+
+template<typename Iteratee>
+bool PathMetadata::for_each_step_of_sense(const handle_t& visited, const std::unordered_set<PathSense>& senses, const Iteratee& iteratee) const {
+    return for_each_step_of_sense_impl(visited, senses, BoolReturningWrapper<Iteratee>::wrap(iteratee));
 }
 
 }

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -163,11 +163,21 @@ public:
     /// stops if the iteratee returns false.
     template<typename Iteratee>
     bool for_each_path_of_sense(const PathSense& sense, const Iteratee& iteratee) const;
+
+    /// Loop through all the paths with any of the given senses. Returns false and
+    /// stops if the iteratee returns false.
+    template<typename Iteratee>
+    bool for_each_path_of_sense(const std::unordered_set<PathSense>& senses, const Iteratee& iteratee) const;
     
     /// Loop through all the paths with the given sample name.
     /// Returns false and stops if the iteratee returns false.
     template<typename Iteratee>
     bool for_each_path_of_sample(const std::string& sample, const Iteratee& iteratee) const;
+
+    /// Loop through all the paths with any of the given sample names.
+    /// Returns false and stops if the iteratee returns false.
+    template<typename Iteratee>
+    bool for_each_path_of_sample(const std::unordered_set<std::string>& samples, const Iteratee& iteratee) const;
     
     /// Loop through all the paths matching the given query. Query elements
     /// which are null match everything. Returns false and stops if the
@@ -275,13 +285,22 @@ private:
 
 template<typename Iteratee>
 bool PathMetadata::for_each_path_of_sense(const PathSense& sense, const Iteratee& iteratee) const {
-    std::unordered_set<PathSense> senses{sense};
+    return for_each_path_of_sense({sense}, iteratee);
+}
+
+template<typename Iteratee>
+bool PathMetadata::for_each_path_of_sense(const std::unordered_set<PathSense>& senses, const Iteratee& iteratee) const {
     return for_each_path_matching_impl(&senses, nullptr, nullptr, BoolReturningWrapper<Iteratee>::wrap(iteratee));
 }
 
 template<typename Iteratee>
 bool PathMetadata::for_each_path_of_sample(const std::string& sample, const Iteratee& iteratee) const {
     std::unordered_set<std::string> samples{sample};
+    return for_each_path_of_sample(samples, iteratee);
+}
+
+template<typename Iteratee>
+bool PathMetadata::for_each_path_of_sample(const std::unordered_set<std::string>& samples, const Iteratee& iteratee) const {
     return for_each_path_matching_impl(nullptr, &samples, nullptr, BoolReturningWrapper<Iteratee>::wrap(iteratee));
 }
 

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -369,5 +369,16 @@ bool PathMetadata::for_each_step_of_sense_impl(const handle_t& visited, const Pa
     });
 }
 
+bool PathMetadata::for_each_step_of_sense_impl(const handle_t& visited, const std::unordered_map<PathSense>& senses, const std::function<bool(const step_handle_t&)>& iteratee) const {
+    return for_each_step_on_handle_impl(visited, [&](const step_handle_t& handle) {
+        if (!senses.count(get_sense(get_path_handle_of_step(handle)))) {
+            // Skip this non-matching path's step
+            return true;
+        }
+        // And emit any steps on matching paths
+        return iteratee(handle);
+    });
+}
+
 }
 

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -369,7 +369,7 @@ bool PathMetadata::for_each_step_of_sense_impl(const handle_t& visited, const Pa
     });
 }
 
-bool PathMetadata::for_each_step_of_sense_impl(const handle_t& visited, const std::unordered_map<PathSense>& senses, const std::function<bool(const step_handle_t&)>& iteratee) const {
+bool PathMetadata::for_each_step_of_sense_impl(const handle_t& visited, const std::unordered_set<PathSense>& senses, const std::function<bool(const step_handle_t&)>& iteratee) const {
     return for_each_step_on_handle_impl(visited, [&](const step_handle_t& handle) {
         if (!senses.count(get_sense(get_path_handle_of_step(handle)))) {
             // Skip this non-matching path's step


### PR DESCRIPTION
Stop hiding paths by sense from the basic iteration interface, and provide multi-sense queries to make it easier to query the senses you actually want.