### PR TITLE
Upstream handlegraph Google-ification behind build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,9 @@ set(CMAKE_CXX_STANDARD 14)
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g")
 
-# By default, libhandlegraph reports fatal errors by throwing C++ exceptions,
-# as it always has. Some embedders (e.g. Google's DeepVariant, which builds
-# with Bazel and -fno-exceptions) need a build that never throws instead.
+# Some embedders (e.g. Google's DeepVariant) build with -fno-exceptions.
 option(HANDLEGRAPH_USE_EXCEPTIONS "Report fatal errors by throwing C++ exceptions" ON)
-# When exceptions are off, fatal errors are reported through Abseil's
-# ABSL_LOG(FATAL) if this is on, or through stderr + std::abort() if it is off.
-# It has no effect when HANDLEGRAPH_USE_EXCEPTIONS is on.
+# Only takes effect when HANDLEGRAPH_USE_EXCEPTIONS is off.
 option(HANDLEGRAPH_USE_ABSEIL_LOGGING "Use Abseil logging to report fatal errors when exceptions are off" OFF)
 
 if(NOT HANDLEGRAPH_USE_EXCEPTIONS)
@@ -152,9 +148,7 @@ set_target_properties(handlegraph_static PROPERTIES OUTPUT_NAME handlegraph)
 target_include_directories(handlegraph_static INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include> $<INSTALL_INTERFACE:include>)
 
 if(NOT HANDLEGRAPH_USE_EXCEPTIONS AND HANDLEGRAPH_USE_ABSEIL_LOGGING)
-  # The object library's PRIVATE link libraries don't propagate through
-  # $<TARGET_OBJECTS:...>, so consumers of these libraries need to see
-  # Abseil too, since the fatal-error path calls into it directly.
+  # PRIVATE link libraries don't propagate through $<TARGET_OBJECTS:...>, so add Abseil explicitly here.
   target_link_libraries(handlegraph_shared PUBLIC absl::log absl::absl_log)
   target_link_libraries(handlegraph_static PUBLIC absl::log absl::absl_log)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,25 @@ set(CMAKE_CXX_STANDARD 14)
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -g")
 
+# By default, libhandlegraph reports fatal errors by throwing C++ exceptions,
+# as it always has. Some embedders (e.g. Google's DeepVariant, which builds
+# with Bazel and -fno-exceptions) need a build that never throws instead.
+option(HANDLEGRAPH_USE_EXCEPTIONS "Report fatal errors by throwing C++ exceptions" ON)
+# When exceptions are off, fatal errors are reported through Abseil's
+# ABSL_LOG(FATAL) if this is on, or through stderr + std::abort() if it is off.
+# It has no effect when HANDLEGRAPH_USE_EXCEPTIONS is on.
+option(HANDLEGRAPH_USE_ABSEIL_LOGGING "Use Abseil logging to report fatal errors when exceptions are off" OFF)
+
+if(NOT HANDLEGRAPH_USE_EXCEPTIONS)
+  message("libhandlegraph: building without C++ exceptions")
+  if(HANDLEGRAPH_USE_ABSEIL_LOGGING)
+    find_package(absl REQUIRED)
+    message("libhandlegraph: fatal errors reported via Abseil ABSL_LOG(FATAL)")
+  else()
+    message("libhandlegraph: fatal errors reported via stderr and std::abort()")
+  endif()
+endif()
+
 # Let cmake decide where to put the output files, allowing for out-of-tree builds.
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -82,6 +101,7 @@ add_library(handlegraph_objs OBJECT
   src/include/handlegraph/util.hpp
   src/include/handlegraph/types.hpp
   src/include/handlegraph/iteratee.hpp
+  src/include/handlegraph/error_handling.hpp
   src/include/handlegraph/algorithms/canonical_gfa.hpp
   src/include/handlegraph/algorithms/copy_graph.hpp
   src/include/handlegraph/algorithms/append_graph.hpp
@@ -109,6 +129,14 @@ add_library(handlegraph_objs OBJECT
 # It can't be picked up via dependency by the other libraries even if it's public.
 target_include_directories(handlegraph_objs PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 
+if(NOT HANDLEGRAPH_USE_EXCEPTIONS)
+  target_compile_definitions(handlegraph_objs PRIVATE HANDLEGRAPH_NO_EXCEPTIONS)
+  if(HANDLEGRAPH_USE_ABSEIL_LOGGING)
+    target_compile_definitions(handlegraph_objs PRIVATE HANDLEGRAPH_USE_ABSEIL_LOGGING)
+    target_link_libraries(handlegraph_objs PUBLIC absl::log absl::absl_log)
+  endif()
+endif()
+
 # Build objects position-independent to allow a shared library
 set_target_properties(handlegraph_objs PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
@@ -122,6 +150,14 @@ target_include_directories(handlegraph_shared INTERFACE $<BUILD_INTERFACE:${CMAK
 add_library(handlegraph_static STATIC $<TARGET_OBJECTS:handlegraph_objs>)
 set_target_properties(handlegraph_static PROPERTIES OUTPUT_NAME handlegraph)
 target_include_directories(handlegraph_static INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/include> $<INSTALL_INTERFACE:include>)
+
+if(NOT HANDLEGRAPH_USE_EXCEPTIONS AND HANDLEGRAPH_USE_ABSEIL_LOGGING)
+  # The object library's PRIVATE link libraries don't propagate through
+  # $<TARGET_OBJECTS:...>, so consumers of these libraries need to see
+  # Abseil too, since the fatal-error path calls into it directly.
+  target_link_libraries(handlegraph_shared PUBLIC absl::log absl::absl_log)
+  target_link_libraries(handlegraph_static PUBLIC absl::log absl::absl_log)
+endif()
 
 # Add an alias so that library can be used inside the build tree, e.g. when testing
 add_library(libhandlegraph::handlegraph_shared ALIAS handlegraph_shared)

--- a/src/copy_graph.cpp
+++ b/src/copy_graph.cpp
@@ -1,3 +1,4 @@
+#include "absl/log/absl_log.h"
 #include "handlegraph/algorithms/copy_graph.hpp"
 
 #include <stdexcept>

--- a/src/copy_graph.cpp
+++ b/src/copy_graph.cpp
@@ -9,15 +9,15 @@ void copy_handle_graph(const HandleGraph* from, MutableHandleGraph* into) {
     
     
     if (from == nullptr) {
-        throw std::runtime_error("error:[copy_handle_graph] must supply graph to copy from");
+        ABSL_LOG(FATAL) << "error:[copy_handle_graph] must supply graph to copy from";
     }
     if (into == nullptr) {
-        throw std::runtime_error("error:[copy_handle_graph] must supply graph to copy into");
+        ABSL_LOG(FATAL) << "error:[copy_handle_graph] must supply graph to copy into";
     }
     
     // TODO: some code paths depend on this algorithm for appending one graph onto another
     //        if (into->get_node_count() > 0) {
-    //            throw runtime_error("error:[copy_handle_graph] cannot copy into a non-empty graph");
+    //            ABSL_LOG(FATAL) << "error:[copy_handle_graph] cannot copy into a non-empty graph";
     //        }
     
     // copy nodes
@@ -41,7 +41,7 @@ void copy_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandl
     
     // TODO: some code paths depend on this algorithm for appending one graph onto another
     //        if (into->get_path_count() > 0) {
-    //            throw runtime_error("error:[copy_handle_graph] cannot copy into a non-empty graph");
+    //            ABSL_LOG(FATAL) << "error:[copy_handle_graph] cannot copy into a non-empty graph";
     //        }
     
     // For every sense of path

--- a/src/copy_graph.cpp
+++ b/src/copy_graph.cpp
@@ -1,5 +1,5 @@
-#include "absl/log/absl_log.h"
 #include "handlegraph/algorithms/copy_graph.hpp"
+#include "handlegraph/error_handling.hpp"
 
 #include <stdexcept>
 
@@ -7,18 +7,18 @@ namespace handlegraph {
 namespace algorithms {
 
 void copy_handle_graph(const HandleGraph* from, MutableHandleGraph* into) {
-    
-    
+
+
     if (from == nullptr) {
-        ABSL_LOG(FATAL) << "error:[copy_handle_graph] must supply graph to copy from";
+        HANDLEGRAPH_THROW(std::runtime_error, "error:[copy_handle_graph] must supply graph to copy from");
     }
     if (into == nullptr) {
-        ABSL_LOG(FATAL) << "error:[copy_handle_graph] must supply graph to copy into";
+        HANDLEGRAPH_THROW(std::runtime_error, "error:[copy_handle_graph] must supply graph to copy into");
     }
     
     // TODO: some code paths depend on this algorithm for appending one graph onto another
     //        if (into->get_node_count() > 0) {
-    //            ABSL_LOG(FATAL) << "error:[copy_handle_graph] cannot copy into a non-empty graph";
+    //            throw runtime_error("error:[copy_handle_graph] cannot copy into a non-empty graph");
     //        }
     
     // copy nodes
@@ -42,7 +42,7 @@ void copy_path_handle_graph(const PathHandleGraph* from, MutablePathMutableHandl
     
     // TODO: some code paths depend on this algorithm for appending one graph onto another
     //        if (into->get_path_count() > 0) {
-    //            ABSL_LOG(FATAL) << "error:[copy_handle_graph] cannot copy into a non-empty graph";
+    //            throw runtime_error("error:[copy_handle_graph] cannot copy into a non-empty graph");
     //        }
     
     // copy paths of every sense of path

--- a/src/copy_graph.cpp
+++ b/src/copy_graph.cpp
@@ -10,10 +10,10 @@ void copy_handle_graph(const HandleGraph* from, MutableHandleGraph* into) {
 
 
     if (from == nullptr) {
-        HANDLEGRAPH_THROW(std::runtime_error, "error:[copy_handle_graph] must supply graph to copy from");
+        HANDLEGRAPH_THROW(std::runtime_error("error:[copy_handle_graph] must supply graph to copy from"));
     }
     if (into == nullptr) {
-        HANDLEGRAPH_THROW(std::runtime_error, "error:[copy_handle_graph] must supply graph to copy into");
+        HANDLEGRAPH_THROW(std::runtime_error("error:[copy_handle_graph] must supply graph to copy into"));
     }
     
     // TODO: some code paths depend on this algorithm for appending one graph onto another

--- a/src/dijkstra.cpp
+++ b/src/dijkstra.cpp
@@ -4,6 +4,7 @@
  * Implementation of Dijkstra's Algorithm over the bidirected graph.
  */
 
+#include "absl/log/absl_log.h"
 #include "handlegraph/algorithms/dijkstra.hpp"
 
 #include <queue>

--- a/src/dijkstra.cpp
+++ b/src/dijkstra.cpp
@@ -271,7 +271,7 @@ unordered_set<handle_t> seen;
 cerr << "At " << g->get_id(current) << (g->get_is_reverse(current) ? "rev" : "fd") << " back to " 
      <<  g->get_id(predecessor.first) << (g->get_is_reverse(predecessor.first) ? "rev" : "fd") << endl;
 if(seen.count(current)){
-    throw runtime_error("Already seen this ");
+    ABSL_LOG(FATAL) << "Already seen this ";
 }
 seen.emplace(current);
 #endif

--- a/src/dijkstra.cpp
+++ b/src/dijkstra.cpp
@@ -272,7 +272,7 @@ unordered_set<handle_t> seen;
 cerr << "At " << g->get_id(current) << (g->get_is_reverse(current) ? "rev" : "fd") << " back to " 
      <<  g->get_id(predecessor.first) << (g->get_is_reverse(predecessor.first) ? "rev" : "fd") << endl;
 if(seen.count(current)){
-    HANDLEGRAPH_THROW(runtime_error, "Already seen this ");
+    HANDLEGRAPH_THROW(runtime_error("Already seen this "));
 }
 seen.emplace(current);
 #endif

--- a/src/dijkstra.cpp
+++ b/src/dijkstra.cpp
@@ -4,8 +4,8 @@
  * Implementation of Dijkstra's Algorithm over the bidirected graph.
  */
 
-#include "absl/log/absl_log.h"
 #include "handlegraph/algorithms/dijkstra.hpp"
+#include "handlegraph/error_handling.hpp"
 
 #include <queue>
 
@@ -272,7 +272,7 @@ unordered_set<handle_t> seen;
 cerr << "At " << g->get_id(current) << (g->get_is_reverse(current) ? "rev" : "fd") << " back to " 
      <<  g->get_id(predecessor.first) << (g->get_is_reverse(predecessor.first) ? "rev" : "fd") << endl;
 if(seen.count(current)){
-    ABSL_LOG(FATAL) << "Already seen this ";
+    HANDLEGRAPH_THROW(runtime_error, "Already seen this ");
 }
 seen.emplace(current);
 #endif

--- a/src/handle_graph.cpp
+++ b/src/handle_graph.cpp
@@ -1,3 +1,4 @@
+#include "absl/log/absl_log.h"
 #include "handlegraph/handle_graph.hpp"
 
 #include "handlegraph/util.hpp"

--- a/src/handle_graph.cpp
+++ b/src/handle_graph.cpp
@@ -54,10 +54,10 @@ handle_t HandleGraph::traverse_edge_handle(const edge_t& edge, const handle_t& l
         return this->flip(edge.first);
     } else {
         // This isn't either handle that the edge actually connects. Something has gone wrong.
-        throw std::runtime_error("Cannot view edge " +
+        ABSL_LOG(FATAL) << "Cannot view edge " +
             std::to_string(this->get_id(edge.first)) + " " + std::to_string(this->get_is_reverse(edge.first)) + " -> " +
             std::to_string(this->get_id(edge.second)) + " " + std::to_string(this->get_is_reverse(edge.second)) +
-            " from non-participant " + std::to_string(this->get_id(left)) + " " + std::to_string(this->get_is_reverse(left)));
+            " from non-participant " + std::to_string(this->get_id(left)) + " " + std::to_string(this->get_is_reverse(left));
     }
 }
 

--- a/src/handle_graph.cpp
+++ b/src/handle_graph.cpp
@@ -1,5 +1,5 @@
-#include "absl/log/absl_log.h"
 #include "handlegraph/handle_graph.hpp"
+#include "handlegraph/error_handling.hpp"
 
 #include "handlegraph/util.hpp"
 
@@ -55,10 +55,10 @@ handle_t HandleGraph::traverse_edge_handle(const edge_t& edge, const handle_t& l
         return this->flip(edge.first);
     } else {
         // This isn't either handle that the edge actually connects. Something has gone wrong.
-        ABSL_LOG(FATAL) << "Cannot view edge " +
+        HANDLEGRAPH_THROW(std::runtime_error, "Cannot view edge " +
             std::to_string(this->get_id(edge.first)) + " " + std::to_string(this->get_is_reverse(edge.first)) + " -> " +
             std::to_string(this->get_id(edge.second)) + " " + std::to_string(this->get_is_reverse(edge.second)) +
-            " from non-participant " + std::to_string(this->get_id(left)) + " " + std::to_string(this->get_is_reverse(left));
+            " from non-participant " + std::to_string(this->get_id(left)) + " " + std::to_string(this->get_is_reverse(left)));
     }
 }
 

--- a/src/handle_graph.cpp
+++ b/src/handle_graph.cpp
@@ -55,10 +55,10 @@ handle_t HandleGraph::traverse_edge_handle(const edge_t& edge, const handle_t& l
         return this->flip(edge.first);
     } else {
         // This isn't either handle that the edge actually connects. Something has gone wrong.
-        HANDLEGRAPH_THROW(std::runtime_error, "Cannot view edge " +
+        HANDLEGRAPH_THROW(std::runtime_error("Cannot view edge " +
             std::to_string(this->get_id(edge.first)) + " " + std::to_string(this->get_is_reverse(edge.first)) + " -> " +
             std::to_string(this->get_id(edge.second)) + " " + std::to_string(this->get_is_reverse(edge.second)) +
-            " from non-participant " + std::to_string(this->get_id(left)) + " " + std::to_string(this->get_is_reverse(left)));
+            " from non-participant " + std::to_string(this->get_id(left)) + " " + std::to_string(this->get_is_reverse(left))));
     }
 }
 

--- a/src/include/handlegraph/buildable_snarl_decomposition.hpp
+++ b/src/include/handlegraph/buildable_snarl_decomposition.hpp
@@ -5,7 +5,7 @@
  * Defines the base SnarlDecomposition interface.
  */
 
-#include "handlegraph/snarl_decomposition.hpp"
+#include "snarl_decomposition.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/deletable_handle_graph.hpp
+++ b/src/include/handlegraph/deletable_handle_graph.hpp
@@ -5,7 +5,7 @@
  * Defines the DeletableHandleGraph interface for graphs that can have material removed.
  */
 
-#include "handlegraph/mutable_handle_graph.hpp"
+#include "mutable_handle_graph.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/error_handling.hpp
+++ b/src/include/handlegraph/error_handling.hpp
@@ -6,34 +6,30 @@
  * unrecoverable errors, so that the error-reporting mechanism can be selected
  * at build time.
  *
- * By default, HANDLEGRAPH_THROW(ExceptionType, message) throws
- * ExceptionType(message), matching libhandlegraph's traditional behavior.
- * Some environments (notably Bazel builds embedding libhandlegraph in
- * exceptions-free code, such as Google's DeepVariant) need to build with
- * -fno-exceptions. Defining HANDLEGRAPH_NO_EXCEPTIONS at build time switches
- * HANDLEGRAPH_THROW to a non-throwing fatal-error path instead: it logs the
- * message with Abseil's ABSL_LOG(FATAL) if HANDLEGRAPH_USE_ABSEIL_LOGGING is
- * also defined, or otherwise prints it to stderr and calls std::abort().
- * Either way, ExceptionType is not evaluated, so it does not need to be a
- * complete type when exceptions are disabled.
+ * HANDLEGRAPH_THROW(exception) throws the given exception object, unless
+ * HANDLEGRAPH_NO_EXCEPTIONS is defined, in which case it logs exception.what()
+ * and calls std::abort() instead (via Abseil if HANDLEGRAPH_USE_ABSEIL_LOGGING
+ * is set).
  */
+
+// HANDLEGRAPH_THROW always constructs its argument, even when not thrown.
+#include <stdexcept>
 
 #if defined(HANDLEGRAPH_NO_EXCEPTIONS)
 
 #if defined(HANDLEGRAPH_USE_ABSEIL_LOGGING)
 #include "absl/log/absl_log.h"
-#define HANDLEGRAPH_THROW(exception_type, message) ABSL_LOG(FATAL) << (message)
+#define HANDLEGRAPH_THROW(exception) ABSL_LOG(FATAL) << (exception).what()
 #else
 #include <cstdlib>
 #include <iostream>
-#define HANDLEGRAPH_THROW(exception_type, message) \
-    do { std::cerr << (message) << std::endl; std::abort(); } while (0)
+#define HANDLEGRAPH_THROW(exception) \
+    do { std::cerr << (exception).what() << std::endl; std::abort(); } while (0)
 #endif
 
 #else
 
-#include <stdexcept>
-#define HANDLEGRAPH_THROW(exception_type, message) throw exception_type(message)
+#define HANDLEGRAPH_THROW(exception) throw (exception)
 
 #endif
 

--- a/src/include/handlegraph/error_handling.hpp
+++ b/src/include/handlegraph/error_handling.hpp
@@ -1,0 +1,40 @@
+#ifndef HANDLEGRAPH_ERROR_HANDLING_HPP_INCLUDED
+#define HANDLEGRAPH_ERROR_HANDLING_HPP_INCLUDED
+
+/** \file
+ * Defines HANDLEGRAPH_THROW, the macro libhandlegraph uses to report
+ * unrecoverable errors, so that the error-reporting mechanism can be selected
+ * at build time.
+ *
+ * By default, HANDLEGRAPH_THROW(ExceptionType, message) throws
+ * ExceptionType(message), matching libhandlegraph's traditional behavior.
+ * Some environments (notably Bazel builds embedding libhandlegraph in
+ * exceptions-free code, such as Google's DeepVariant) need to build with
+ * -fno-exceptions. Defining HANDLEGRAPH_NO_EXCEPTIONS at build time switches
+ * HANDLEGRAPH_THROW to a non-throwing fatal-error path instead: it logs the
+ * message with Abseil's ABSL_LOG(FATAL) if HANDLEGRAPH_USE_ABSEIL_LOGGING is
+ * also defined, or otherwise prints it to stderr and calls std::abort().
+ * Either way, ExceptionType is not evaluated, so it does not need to be a
+ * complete type when exceptions are disabled.
+ */
+
+#if defined(HANDLEGRAPH_NO_EXCEPTIONS)
+
+#if defined(HANDLEGRAPH_USE_ABSEIL_LOGGING)
+#include "absl/log/absl_log.h"
+#define HANDLEGRAPH_THROW(exception_type, message) ABSL_LOG(FATAL) << (message)
+#else
+#include <cstdlib>
+#include <iostream>
+#define HANDLEGRAPH_THROW(exception_type, message) \
+    do { std::cerr << (message) << std::endl; std::abort(); } while (0)
+#endif
+
+#else
+
+#include <stdexcept>
+#define HANDLEGRAPH_THROW(exception_type, message) throw exception_type(message)
+
+#endif
+
+#endif

--- a/src/include/handlegraph/expanding_overlay_graph.hpp
+++ b/src/include/handlegraph/expanding_overlay_graph.hpp
@@ -5,7 +5,7 @@
  * Defines an interface for overlay graphs that duplicate underlying graph nodes.
  */
  
-#include "handlegraph/handle_graph.hpp"
+#include "handle_graph.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/handle_graph.hpp
+++ b/src/include/handlegraph/handle_graph.hpp
@@ -5,8 +5,8 @@
  * Defines the base HandleGraph interface.
  */
  
-#include "handlegraph/types.hpp"
-#include "handlegraph/iteratee.hpp"
+#include "types.hpp"
+#include "iteratee.hpp"
 
 #include <functional>
 #include <string>

--- a/src/include/handlegraph/mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_handle_graph.hpp
@@ -5,7 +5,7 @@
  * Defines the MutableHandleGraph interface for graphs that can be added to.
  */
 
-#include "handlegraph/handle_graph.hpp"
+#include "handle_graph.hpp"
 
 #include <functional>
 #include <vector>

--- a/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_deletable_handle_graph.hpp
@@ -5,8 +5,8 @@
  * Defines the MutablePathDeletableeHandleGraph interface for graphs that can have paths changed and graph material deleted.
  */
 
-#include "handlegraph/mutable_path_mutable_handle_graph.hpp"
-#include "handlegraph/deletable_handle_graph.hpp"
+#include "mutable_path_mutable_handle_graph.hpp"
+#include "deletable_handle_graph.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/mutable_path_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_handle_graph.hpp
@@ -5,8 +5,8 @@
  * Defines the MutablePathHandleGraph interface for graphs that can have paths altered.
  */
 
-#include "handlegraph/path_handle_graph.hpp"
-#include "handlegraph/mutable_path_metadata.hpp"
+#include "path_handle_graph.hpp"
+#include "mutable_path_metadata.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/mutable_path_metadata.hpp
+++ b/src/include/handlegraph/mutable_path_metadata.hpp
@@ -5,7 +5,7 @@
  * Defines the mutable metadata API for paths
  */
 
-#include "handlegraph/path_metadata.hpp"
+#include "path_metadata.hpp"
 
 #include <vector>
 

--- a/src/include/handlegraph/mutable_path_mutable_handle_graph.hpp
+++ b/src/include/handlegraph/mutable_path_mutable_handle_graph.hpp
@@ -5,8 +5,8 @@
  * Defines the MutablePathMutableHandleGraph interface for graphs that can have paths and graph material changed.
  */
 
-#include "handlegraph/mutable_path_handle_graph.hpp"
-#include "handlegraph/mutable_handle_graph.hpp"
+#include "mutable_path_handle_graph.hpp"
+#include "mutable_handle_graph.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/named_node_back_translation.hpp
+++ b/src/include/handlegraph/named_node_back_translation.hpp
@@ -7,7 +7,7 @@
  * nodes in some other graph, where the destination graph nodes have names.
  */
 
-#include "handlegraph/handle_graph.hpp"
+#include "handle_graph.hpp"
 
 #include <vector>
 

--- a/src/include/handlegraph/named_node_back_translation.hpp
+++ b/src/include/handlegraph/named_node_back_translation.hpp
@@ -7,7 +7,7 @@
  * nodes in some other graph, where the destination graph nodes have names.
  */
 
-#include "handle_graph.hpp"
+#include "types.hpp"
 
 #include <vector>
 

--- a/src/include/handlegraph/path_handle_graph.hpp
+++ b/src/include/handlegraph/path_handle_graph.hpp
@@ -5,8 +5,8 @@
  * Defines the PathHandleGraph interface for graphs that have embedded paths.
  */
 
-#include "handlegraph/handle_graph.hpp"
-#include "handlegraph/path_metadata.hpp"
+#include "handle_graph.hpp"
+#include "path_metadata.hpp"
 
 #include <vector>
 

--- a/src/include/handlegraph/path_metadata.hpp
+++ b/src/include/handlegraph/path_metadata.hpp
@@ -5,7 +5,7 @@
  * Defines the metadata API for paths
  */
 
-#include "handlegraph/handle_graph.hpp"
+#include "handle_graph.hpp"
 
 #include <utility>
 #include <string>

--- a/src/include/handlegraph/path_position_handle_graph.hpp
+++ b/src/include/handlegraph/path_position_handle_graph.hpp
@@ -5,8 +5,8 @@
  * Defines the PathPositionHandleGraph interface.
  */
 
-#include "handlegraph/path_handle_graph.hpp"
-#include "handlegraph/iteratee.hpp"
+#include "path_handle_graph.hpp"
+#include "iteratee.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/serializable_handle_graph.hpp
+++ b/src/include/handlegraph/serializable_handle_graph.hpp
@@ -5,7 +5,7 @@
  * Defines the base SerializableHandleGraph interface.
  */
 
-#include "handlegraph/serializable.hpp"
+#include "serializable.hpp"
 
 namespace handlegraph {
 

--- a/src/include/handlegraph/snarl_decomposition.hpp
+++ b/src/include/handlegraph/snarl_decomposition.hpp
@@ -5,11 +5,11 @@
  * Defines the base SnarlDecomposition interface.
  */
 
-#include "handlegraph/types.hpp"
+#include "types.hpp"
 
-#include "handlegraph/handle_graph.hpp"
+#include "handle_graph.hpp"
 
-#include "handlegraph/iteratee.hpp"
+#include "iteratee.hpp"
 
 #include <functional>
 

--- a/src/include/handlegraph/trivially_serializable.hpp
+++ b/src/include/handlegraph/trivially_serializable.hpp
@@ -5,7 +5,7 @@
  * Defines an interface for objects that us the same representation in memory and on disk. 
  */
 
-#include "handlegraph/serializable.hpp"
+#include "serializable.hpp"
 
 #include <iostream>
 #include <limits>

--- a/src/include/handlegraph/util.hpp
+++ b/src/include/handlegraph/util.hpp
@@ -5,7 +5,7 @@
  * Tools for handle graph implementers to pack and unpack handles.
  */
 
-#include "handlegraph/types.hpp"
+#include "types.hpp"
 
 #include <cassert>
 

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -281,47 +281,47 @@ std::string PathMetadata::create_path_name(const PathSense& sense,
     
     if (sample != NO_SAMPLE_NAME) {
         if (sense == PathSense::GENERIC) {
-            throw std::runtime_error("Generic path cannot have a sample");
+            ABSL_LOG(FATAL) << "Generic path cannot have a sample";
         }
         name_builder << sample << SEPARATOR;
     } else {
         if (sense == PathSense::REFERENCE) {
-            throw std::runtime_error("Reference path must have a sample name");
+            ABSL_LOG(FATAL) << "Reference path must have a sample name";
         } else if (sense == PathSense::HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path must have a sample name");
+            ABSL_LOG(FATAL) << "Haplotype path must have a sample name";
         }
     }
     if (haplotype != NO_HAPLOTYPE) {
         if (sense == PathSense::GENERIC) {
-            throw std::runtime_error("Generic path cannot have a haplotype number");
+            ABSL_LOG(FATAL) << "Generic path cannot have a haplotype number";
         }
         name_builder << haplotype << SEPARATOR;
     } else {
         if (sense == PathSense::HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path must have a haplotype number");
+            ABSL_LOG(FATAL) << "Haplotype path must have a haplotype number";
         }
     }
     if (locus != NO_LOCUS_NAME) {
         name_builder << locus;
     } else {
         if (sense == PathSense::GENERIC) {
-            throw std::runtime_error("Generic path must have a locus/name");
+            ABSL_LOG(FATAL) << "Generic path must have a locus/name";
         } else if (sense == PathSense::REFERENCE) {
-            throw std::runtime_error("Reference path must have a locus");
+            ABSL_LOG(FATAL) << "Reference path must have a locus";
         } else if (sense == PathSense::HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path must have a locus");
+            ABSL_LOG(FATAL) << "Haplotype path must have a locus";
         }
     }
     if (phase_block != NO_PHASE_BLOCK) {
         if (sense == PathSense::GENERIC) {
-            throw std::runtime_error("Generic path cannot have a phase block");
+            ABSL_LOG(FATAL) << "Generic path cannot have a phase block";
         } else if (sense == PathSense::REFERENCE) {
-            throw std::runtime_error("Reference path cannot have a phase block");
+            ABSL_LOG(FATAL) << "Reference path cannot have a phase block";
         }
         name_builder << SEPARATOR << phase_block;
     } else {
         if (sense == PathSense::HAPLOTYPE) {
-            throw std::runtime_error("Haplotype path must have a phase block");
+            ABSL_LOG(FATAL) << "Haplotype path must have a phase block";
         }
     }
     if (subrange != NO_SUBRANGE) {

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -2,6 +2,7 @@
  * Implement PathMetadata interface's default implementation.
  */
 
+#include "absl/log/absl_log.h"
 #include "handlegraph/path_metadata.hpp"
 #include <sstream>
 

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -2,8 +2,8 @@
  * Implement PathMetadata interface's default implementation.
  */
 
-#include "absl/log/absl_log.h"
 #include "handlegraph/path_metadata.hpp"
+#include "handlegraph/error_handling.hpp"
 #include <sstream>
 
 namespace handlegraph {
@@ -282,47 +282,47 @@ std::string PathMetadata::create_path_name(const PathSense& sense,
     
     if (sample != NO_SAMPLE_NAME) {
         if (sense == PathSense::GENERIC) {
-            ABSL_LOG(FATAL) << "Generic path cannot have a sample";
+            HANDLEGRAPH_THROW(std::runtime_error, "Generic path cannot have a sample");
         }
         name_builder << sample << SEPARATOR;
     } else {
         if (sense == PathSense::REFERENCE) {
-            ABSL_LOG(FATAL) << "Reference path must have a sample name";
+            HANDLEGRAPH_THROW(std::runtime_error, "Reference path must have a sample name");
         } else if (sense == PathSense::HAPLOTYPE) {
-            ABSL_LOG(FATAL) << "Haplotype path must have a sample name";
+            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a sample name");
         }
     }
     if (haplotype != NO_HAPLOTYPE) {
         if (sense == PathSense::GENERIC) {
-            ABSL_LOG(FATAL) << "Generic path cannot have a haplotype number";
+            HANDLEGRAPH_THROW(std::runtime_error, "Generic path cannot have a haplotype number");
         }
         name_builder << haplotype << SEPARATOR;
     } else {
         if (sense == PathSense::HAPLOTYPE) {
-            ABSL_LOG(FATAL) << "Haplotype path must have a haplotype number";
+            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a haplotype number");
         }
     }
     if (locus != NO_LOCUS_NAME) {
         name_builder << locus;
     } else {
         if (sense == PathSense::GENERIC) {
-            ABSL_LOG(FATAL) << "Generic path must have a locus/name";
+            HANDLEGRAPH_THROW(std::runtime_error, "Generic path must have a locus/name");
         } else if (sense == PathSense::REFERENCE) {
-            ABSL_LOG(FATAL) << "Reference path must have a locus";
+            HANDLEGRAPH_THROW(std::runtime_error, "Reference path must have a locus");
         } else if (sense == PathSense::HAPLOTYPE) {
-            ABSL_LOG(FATAL) << "Haplotype path must have a locus";
+            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a locus");
         }
     }
     if (phase_block != NO_PHASE_BLOCK) {
         if (sense == PathSense::GENERIC) {
-            ABSL_LOG(FATAL) << "Generic path cannot have a phase block";
+            HANDLEGRAPH_THROW(std::runtime_error, "Generic path cannot have a phase block");
         } else if (sense == PathSense::REFERENCE) {
-            ABSL_LOG(FATAL) << "Reference path cannot have a phase block";
+            HANDLEGRAPH_THROW(std::runtime_error, "Reference path cannot have a phase block");
         }
         name_builder << SEPARATOR << phase_block;
     } else {
         if (sense == PathSense::HAPLOTYPE) {
-            ABSL_LOG(FATAL) << "Haplotype path must have a phase block";
+            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a phase block");
         }
     }
     if (subrange != NO_SUBRANGE) {

--- a/src/path_metadata.cpp
+++ b/src/path_metadata.cpp
@@ -282,47 +282,47 @@ std::string PathMetadata::create_path_name(const PathSense& sense,
     
     if (sample != NO_SAMPLE_NAME) {
         if (sense == PathSense::GENERIC) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Generic path cannot have a sample");
+            HANDLEGRAPH_THROW(std::runtime_error("Generic path cannot have a sample"));
         }
         name_builder << sample << SEPARATOR;
     } else {
         if (sense == PathSense::REFERENCE) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Reference path must have a sample name");
+            HANDLEGRAPH_THROW(std::runtime_error("Reference path must have a sample name"));
         } else if (sense == PathSense::HAPLOTYPE) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a sample name");
+            HANDLEGRAPH_THROW(std::runtime_error("Haplotype path must have a sample name"));
         }
     }
     if (haplotype != NO_HAPLOTYPE) {
         if (sense == PathSense::GENERIC) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Generic path cannot have a haplotype number");
+            HANDLEGRAPH_THROW(std::runtime_error("Generic path cannot have a haplotype number"));
         }
         name_builder << haplotype << SEPARATOR;
     } else {
         if (sense == PathSense::HAPLOTYPE) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a haplotype number");
+            HANDLEGRAPH_THROW(std::runtime_error("Haplotype path must have a haplotype number"));
         }
     }
     if (locus != NO_LOCUS_NAME) {
         name_builder << locus;
     } else {
         if (sense == PathSense::GENERIC) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Generic path must have a locus/name");
+            HANDLEGRAPH_THROW(std::runtime_error("Generic path must have a locus/name"));
         } else if (sense == PathSense::REFERENCE) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Reference path must have a locus");
+            HANDLEGRAPH_THROW(std::runtime_error("Reference path must have a locus"));
         } else if (sense == PathSense::HAPLOTYPE) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a locus");
+            HANDLEGRAPH_THROW(std::runtime_error("Haplotype path must have a locus"));
         }
     }
     if (phase_block != NO_PHASE_BLOCK) {
         if (sense == PathSense::GENERIC) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Generic path cannot have a phase block");
+            HANDLEGRAPH_THROW(std::runtime_error("Generic path cannot have a phase block"));
         } else if (sense == PathSense::REFERENCE) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Reference path cannot have a phase block");
+            HANDLEGRAPH_THROW(std::runtime_error("Reference path cannot have a phase block"));
         }
         name_builder << SEPARATOR << phase_block;
     } else {
         if (sense == PathSense::HAPLOTYPE) {
-            HANDLEGRAPH_THROW(std::runtime_error, "Haplotype path must have a phase block");
+            HANDLEGRAPH_THROW(std::runtime_error("Haplotype path must have a phase block"));
         }
     }
     if (subrange != NO_SUBRANGE) {

--- a/src/serializable.cpp
+++ b/src/serializable.cpp
@@ -1,3 +1,4 @@
+#include "absl/log/absl_log.h"
 #include "handlegraph/serializable.hpp"
 
 #include <fstream>

--- a/src/serializable.cpp
+++ b/src/serializable.cpp
@@ -52,7 +52,7 @@ void Serializable::deserialize(std::istream& in) {
         
         if (!in) {
             // The stream did not rewind right (or was already at EOF somehow)
-            throw std::runtime_error("Error rewinding to load non-magic-prefixed SerializableHandleGraph");
+            ABSL_LOG(FATAL) << "Error rewinding to load non-magic-prefixed SerializableHandleGraph";
         }
     }
     deserialize_members(in);

--- a/src/serializable.cpp
+++ b/src/serializable.cpp
@@ -53,7 +53,7 @@ void Serializable::deserialize(std::istream& in) {
         
         if (!in) {
             // The stream did not rewind right (or was already at EOF somehow)
-            HANDLEGRAPH_THROW(std::runtime_error, "Error rewinding to load non-magic-prefixed SerializableHandleGraph");
+            HANDLEGRAPH_THROW(std::runtime_error("Error rewinding to load non-magic-prefixed SerializableHandleGraph"));
         }
     }
     deserialize_members(in);

--- a/src/serializable.cpp
+++ b/src/serializable.cpp
@@ -1,5 +1,5 @@
-#include "absl/log/absl_log.h"
 #include "handlegraph/serializable.hpp"
+#include "handlegraph/error_handling.hpp"
 
 #include <fstream>
 #include <arpa/inet.h>
@@ -53,7 +53,7 @@ void Serializable::deserialize(std::istream& in) {
         
         if (!in) {
             // The stream did not rewind right (or was already at EOF somehow)
-            ABSL_LOG(FATAL) << "Error rewinding to load non-magic-prefixed SerializableHandleGraph";
+            HANDLEGRAPH_THROW(std::runtime_error, "Error rewinding to load non-magic-prefixed SerializableHandleGraph");
         }
     }
     deserialize_members(in);

--- a/src/trivially_serializable.cpp
+++ b/src/trivially_serializable.cpp
@@ -26,7 +26,7 @@ void TriviallySerializable::serialize(int fd) const {
             auto result = write(fd, (const void*)((const char*) start + written), length - written);
             if (result == -1) {
                 // Can't write at all, something broke.
-                throw std::runtime_error("Could not write!");
+                ABSL_LOG(FATAL) << "Could not write!";
             }
             written += result;
         }
@@ -92,7 +92,7 @@ int TriviallySerializable::open_fd(const std::string& filename) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not save to file " << filename << ": " << ::strerror(problem);
-        throw std::runtime_error(ss.str());
+        ABSL_LOG(FATAL) << ss.str(;
     }
     
     return fd;
@@ -105,7 +105,7 @@ void TriviallySerializable::close_fd(int fd) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not close FD: " << ::strerror(problem);
-        throw std::runtime_error(ss.str());
+        ABSL_LOG(FATAL) << ss.str(;
     }
 }
 
@@ -144,7 +144,7 @@ void TriviallySerializable::deserialize(const std::string& filename) {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not load from file " << filename << ": " << ::strerror(problem);
-        throw std::runtime_error(ss.str());
+        ABSL_LOG(FATAL) << ss.str(;
     }
     
     // Deserialize from the file

--- a/src/trivially_serializable.cpp
+++ b/src/trivially_serializable.cpp
@@ -93,7 +93,7 @@ int TriviallySerializable::open_fd(const std::string& filename) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not save to file " << filename << ": " << ::strerror(problem);
-        ABSL_LOG(FATAL) << ss.str(;
+        ABSL_LOG(FATAL) << ss.str();
     }
     
     return fd;
@@ -106,7 +106,7 @@ void TriviallySerializable::close_fd(int fd) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not close FD: " << ::strerror(problem);
-        ABSL_LOG(FATAL) << ss.str(;
+        ABSL_LOG(FATAL) << ss.str();
     }
 }
 
@@ -145,7 +145,7 @@ void TriviallySerializable::deserialize(const std::string& filename) {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not load from file " << filename << ": " << ::strerror(problem);
-        ABSL_LOG(FATAL) << ss.str(;
+        ABSL_LOG(FATAL) << ss.str();
     }
     
     // Deserialize from the file

--- a/src/trivially_serializable.cpp
+++ b/src/trivially_serializable.cpp
@@ -1,3 +1,4 @@
+#include "absl/log/absl_log.h"
 #include "handlegraph/trivially_serializable.hpp"
 
 #include <unistd.h>

--- a/src/trivially_serializable.cpp
+++ b/src/trivially_serializable.cpp
@@ -27,7 +27,7 @@ void TriviallySerializable::serialize(int fd) const {
             auto result = write(fd, (const void*)((const char*) start + written), length - written);
             if (result == -1) {
                 // Can't write at all, something broke.
-                HANDLEGRAPH_THROW(std::runtime_error, "Could not write!");
+                HANDLEGRAPH_THROW(std::runtime_error("Could not write!"));
             }
             written += result;
         }
@@ -93,7 +93,7 @@ int TriviallySerializable::open_fd(const std::string& filename) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not save to file " << filename << ": " << ::strerror(problem);
-        HANDLEGRAPH_THROW(std::runtime_error, ss.str());
+        HANDLEGRAPH_THROW(std::runtime_error(ss.str()));
     }
     
     return fd;
@@ -106,7 +106,7 @@ void TriviallySerializable::close_fd(int fd) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not close FD: " << ::strerror(problem);
-        HANDLEGRAPH_THROW(std::runtime_error, ss.str());
+        HANDLEGRAPH_THROW(std::runtime_error(ss.str()));
     }
 }
 
@@ -145,7 +145,7 @@ void TriviallySerializable::deserialize(const std::string& filename) {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not load from file " << filename << ": " << ::strerror(problem);
-        HANDLEGRAPH_THROW(std::runtime_error, ss.str());
+        HANDLEGRAPH_THROW(std::runtime_error(ss.str()));
     }
     
     // Deserialize from the file

--- a/src/trivially_serializable.cpp
+++ b/src/trivially_serializable.cpp
@@ -1,5 +1,5 @@
-#include "absl/log/absl_log.h"
 #include "handlegraph/trivially_serializable.hpp"
+#include "handlegraph/error_handling.hpp"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -27,7 +27,7 @@ void TriviallySerializable::serialize(int fd) const {
             auto result = write(fd, (const void*)((const char*) start + written), length - written);
             if (result == -1) {
                 // Can't write at all, something broke.
-                ABSL_LOG(FATAL) << "Could not write!";
+                HANDLEGRAPH_THROW(std::runtime_error, "Could not write!");
             }
             written += result;
         }
@@ -93,7 +93,7 @@ int TriviallySerializable::open_fd(const std::string& filename) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not save to file " << filename << ": " << ::strerror(problem);
-        ABSL_LOG(FATAL) << ss.str();
+        HANDLEGRAPH_THROW(std::runtime_error, ss.str());
     }
     
     return fd;
@@ -106,7 +106,7 @@ void TriviallySerializable::close_fd(int fd) const {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not close FD: " << ::strerror(problem);
-        ABSL_LOG(FATAL) << ss.str();
+        HANDLEGRAPH_THROW(std::runtime_error, ss.str());
     }
 }
 
@@ -145,7 +145,7 @@ void TriviallySerializable::deserialize(const std::string& filename) {
         auto problem = errno;
         std::stringstream ss;
         ss << "Could not load from file " << filename << ": " << ::strerror(problem);
-        ABSL_LOG(FATAL) << ss.str();
+        HANDLEGRAPH_THROW(std::runtime_error, ss.str());
     }
     
     // Deserialize from the file


### PR DESCRIPTION
This brings in the changes @mobinasri made for pangenome-aware DeepVariant and tries to put particularly Googley ones (like not throwing exceptions) behind build flags.

Much of the work here is synthetic, so I need to review it before anyone else looks at it.

This is related to https://github.com/vgteam/sdsl-lite/pull/21